### PR TITLE
Fix for issue 435 ":<line number>" should reach the end of file if line number > # of lines of file

### DIFF
--- a/VimCore/Modes_Command_RangeUtil.fs
+++ b/VimCore/Modes_Command_RangeUtil.fs
@@ -91,13 +91,9 @@ module internal RangeUtil =
         let opt,remaining = ParseNumber input
         match opt with 
         | Some(number) ->
-            let number = TssUtil.VimLineToTssLine number
-            if number < tss.LineCount then 
-                let range = tss.GetLineFromLineNumber(number) |> SnapshotLineRangeUtil.CreateForLine
-                ValidRange(range, LineNumber, remaining)
-            else
-                let msg = sprintf "Invalid Range: Line Number %d is not a valid number in the file" number
-                Error(msg)
+            let number = min (TssUtil.VimLineToTssLine number) (tss.LineCount - 1)
+            let range = tss.GetLineFromLineNumber(number) |> SnapshotLineRangeUtil.CreateForLine
+            ValidRange(range, LineNumber, remaining)
         | None -> Error("Expected a line number")
 
     /// Parse out a mark 

--- a/VimCoreTest/CommandProcessorTest.cs
+++ b/VimCoreTest/CommandProcessorTest.cs
@@ -142,7 +142,7 @@ namespace VimCore.UnitTest
         public void Jump3()
         {
             Create("foo");
-            _statusUtil.Setup(x => x.OnError(It.IsAny<string>())).Verifiable();
+            _operations.Setup(x => x.MoveCaretToPoint(_textView.GetLastLine().Start)).Verifiable();
             RunCommand("400");
             _factory.Verify();
         }


### PR DESCRIPTION
Fixed Modes_Command_RangeUtil.fs to always get the min of line numeber or total lines of the file.
Also fixed test Jump3 since the behavior is changed.
