### PR TITLE
HOMEDRIVE + HOMEPATH take precedence over USERPROFILE

### DIFF
--- a/VimCore/FileSystem.fs
+++ b/VimCore/FileSystem.fs
@@ -1,4 +1,4 @@
-﻿#light
+#light
 
 namespace Vim
 open System.IO
@@ -37,7 +37,8 @@ type internal FileSystem() =
 
     member x.GetVimRcDirectories() = 
         let getEnvVarValue var = 
-            match System.Environment.ExpandEnvironmentVariable(var) with
+            match System.Environment.ExpandEnvironmentVariables(var) with
+            | var1 when System.String.Equals(var1,var,System.StringComparison.InvariantCultureIgnoreCase) -> None
             | null -> None
             | value -> Some(value)
 

--- a/VimCoreTest/FileSystemTest.cs
+++ b/VimCoreTest/FileSystemTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -19,7 +19,8 @@ namespace VimCore.UnitTest
             _fileSystemRaw = new FileSystem();
             _fileSystem = _fileSystemRaw;
             _savedEnvVariables = new Dictionary<string,string>();
-            foreach ( var name in _fileSystem.EnvironmentVariables )
+			
+            foreach ( var name in _fileSystem.EnvironmentVariables.SelectMany(ev => ev.Split(new[] { '%'}, StringSplitOptions.RemoveEmptyEntries)))
             {
                 _savedEnvVariables[name] = Environment.GetEnvironmentVariable(name);
                 Environment.SetEnvironmentVariable(name, null);
@@ -58,6 +59,19 @@ namespace VimCore.UnitTest
             Assert.AreEqual(@"c:\temp\.vimrc", list[2]);
             Assert.AreEqual(@"c:\temp\_vimrc", list[3]);
         }
+
+		[Test]
+		public void HomeDrivePathTakesPrecedenceOverUserProfile()
+		{
+			Environment.SetEnvironmentVariable("HOMEDRIVE", "c:");
+			Environment.SetEnvironmentVariable("HOMEPATH", "\\temp");
+			Environment.SetEnvironmentVariable("USERPROFILE", "c:\\Users");
+            var list = _fileSystem.GetVimRcFilePaths().ToList();
+            Assert.AreEqual(@"c:\temp\.vsvimrc", list[0]);
+            Assert.AreEqual(@"c:\temp\_vsvimrc", list[1]);
+            Assert.AreEqual(@"c:\temp\.vimrc", list[2]);
+            Assert.AreEqual(@"c:\temp\_vimrc", list[3]);
+		}
 
     }
 }


### PR DESCRIPTION
Path + test to verify it.

Regarding the fix in FileSystem.fs - since this is my first encounter with F#, I don't know if that's pretty or not. Unlike GetEnvVar, ExpandEnvVars will return the input string if it cannot expand it (e.g., because the Env Var doesn't exist). 
I suppose it could fail if HOMEDRIVE is defined but HOMEPATH isn't, but that's no different than say %VIM% pointing to a wrong folder.
