### PR TITLE
Fix memory leak in the CommandMargin

### DIFF
--- a/VimCore/CoreInterfaces.fs
+++ b/VimCore/CoreInterfaces.fs
@@ -2283,7 +2283,7 @@ type IMacroRecorder =
 
     /// Raised when a macro recording is completed.
     [<CLIEvent>]
-    abstract RecordingStopped : IEvent<unit>
+    abstract RecordingStopped : IEvent<System.EventArgs>
 
 [<RequireQualifiedAccess>]
 type ProcessResult = 

--- a/VimCore/MacroRecorder.fs
+++ b/VimCore/MacroRecorder.fs
@@ -44,7 +44,7 @@ type internal MacroRecorder (_registerMap : IRegisterMap) =
         _registerMap.SetRegisterValue register RegisterOperation.Yank value
         _recordData <- None
         _recordKeyStroke <- false
-        _recordingStoppedEvent.Trigger ()
+        _recordingStoppedEvent.Trigger System.EventArgs.Empty
 
     /// Need to track the KeyInputProcessed event for every IVimBuffer in the system
     member x.OnVimBufferCreated (buffer : IVimBuffer) =

--- a/VimWpf/CommandMargin.cs
+++ b/VimWpf/CommandMargin.cs
@@ -41,7 +41,7 @@ namespace Vim.UI.Wpf
 
         public void Dispose()
         {
-
+            _controller.Disconnect();
         }
     }
 }

--- a/VimWpf/CommandMarginController.cs
+++ b/VimWpf/CommandMarginController.cs
@@ -33,12 +33,18 @@ namespace Vim.UI.Wpf
             _buffer.StatusMessage += OnStatusMessage;
             _buffer.ErrorMessage += OnErrorMessage;
             _buffer.WarningMessage += OnWarningMessage;
-            _buffer.Vim.MacroRecorder.RecordingStarted += delegate { UpdateForRecordingChanged(); };
-            _buffer.Vim.MacroRecorder.RecordingStopped += delegate { UpdateForRecordingChanged(); };
+            _buffer.Vim.MacroRecorder.RecordingStarted += OnRecordingStarted;
+            _buffer.Vim.MacroRecorder.RecordingStopped += OnRecordingStopped;
             _margin.OptionsClicked += OnOptionsClicked;
             _editorFormatMap.FormatMappingChanged += OnFormatMappingChanged;
             UpdateForRecordingChanged();
             UpdateTextColor();
+        }
+
+        internal void Disconnect()
+        {
+            _buffer.Vim.MacroRecorder.RecordingStarted -= OnRecordingStarted;
+            _buffer.Vim.MacroRecorder.RecordingStopped -= OnRecordingStopped;
         }
 
         private void KeyInputEventComplete()
@@ -259,6 +265,16 @@ namespace Vim.UI.Wpf
         private void OnFormatMappingChanged(object sender, FormatItemsEventArgs e)
         {
             UpdateTextColor();
+        }
+
+        private void OnRecordingStarted(object sender, Tuple<Register, bool> e)
+        {
+            UpdateForRecordingChanged();
+        }
+
+        private void OnRecordingStopped(object sender, EventArgs e)
+        {
+            UpdateForRecordingChanged();
         }
 
         #endregion

--- a/VsVimTest/MemoryLeakTest.cs
+++ b/VsVimTest/MemoryLeakTest.cs
@@ -216,6 +216,27 @@ namespace VsVim.UnitTest
             Assert.IsNull(weakReference.Target);
         }
 
+        /// <summary>
+        /// Run a sanity check which just tests the ability for an ITextViewHost to be created
+        /// and closed without leaking memory that doesn't involve the creation of an
+        /// IVimBuffer
+        /// </summary>
+        [Test]
+        public void TextViewHostOnly()
+        {
+            var container = GetOrCreateCompositionContainer();
+            var factory = container.GetExport<ITextEditorFactoryService>().Value;
+            var textView = factory.CreateTextView();
+            var textViewHost = factory.CreateTextViewHost(textView, setFocus: true);
+            var weakReference = new WeakReference(textViewHost);
+            textViewHost.Close();
+            textView = null;
+            textViewHost = null;
+
+            RunGarbageCollector();
+            Assert.IsNull(weakReference.Target);
+        }
+
         [Test]
         public void VimWpfDoesntHoldBuffer()
         {


### PR DESCRIPTION
The command margin, when it is created, attaches itself to several events
on the singleton MacroRecorder. It never detached these, so it'd leak all
ITextViews that it was loaded for. There was only a test that checked for
leaks when creating an ITextView, not an ITextViewHost, so this one slipped
through the cracks. I've added the test to guard against future leaks like
this.
