### PR TITLE
Defaulted regex replace to magic mode

### DIFF
--- a/VimCore/VimRegex.fs
+++ b/VimCore/VimRegex.fs
@@ -476,8 +476,8 @@ module VimRegexFactory =
 
         // Get the magic options
         let options = 
-            if Util.IsFlagSet flags SubstituteFlags.Magic then options 
-            else options ||| VimRegexOptions.NoMagic
+            if Util.IsFlagSet flags SubstituteFlags.Nomagic then options ||| VimRegexOptions.NoMagic
+            else options 
 
         Create pattern options 
 

--- a/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/VimCoreTest/CommandModeIntegrationTest.cs
@@ -279,6 +279,15 @@ namespace Vim.UnitTest
             Assert.AreEqual(_textView.GetLine(2).Start, _textView.GetCaretPoint());
         }
 
+        [Test]
+        public void Substitute_DefaultsToMagicMode()
+        {
+            Create("a.c", "abc");
+            RunCommand(@"%s/a\.c/replaced/g");
+            Assert.That(_textView.GetLine(0).GetText(), Is.EqualTo("replaced"));
+            Assert.That(_textView.GetLine(1).GetText(), Is.EqualTo("abc"));
+        }
+
         /// <summary>
         /// Using the search forward feature which doesn't hit a match in the specified path.  Should 
         /// raise a warning


### PR DESCRIPTION
This provides a fix to #689 and should clear up some other discrepancies
between search & substitute.
