### PR TITLE
Made \n match \r, \n, and \r\n for both search & replace

### DIFF
--- a/VimCore/VimRegex.fs
+++ b/VimCore/VimRegex.fs
@@ -361,7 +361,10 @@ module VimRegexFactory =
         | 'v' -> {data with MagicKind = MagicKind.VeryMagic }
         | 'V' -> {data with MagicKind = MagicKind.VeryNoMagic }
         | 't' -> data.AppendString "\t"
-        | 'n' -> data.AppendString "\n"
+        // vim expects \n to match any kind of newline, regardless of platform. Think about it,
+        // you can't see newlines, so why should you be expected to know the diff between them?
+        // Also, use ?: for non-capturing group, so we don't cause any weird behavior
+        | 'n' -> data.AppendString "(?:\r?\n|\r)"
         | _ ->
             let data = 
                 match data.MagicKind with

--- a/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/VimCoreTest/CommandModeIntegrationTest.cs
@@ -288,6 +288,14 @@ namespace Vim.UnitTest
             Assert.That(_textView.GetLine(1).GetText(), Is.EqualTo("abc"));
         }
 
+        [Test]
+        public void Substitute_NewlinesCanBeReplaced()
+        {
+            Create("foo", "bar");
+            RunCommand(@"%s/\n/ /");
+            Assert.That(_textView.GetLine(0).GetText(), Is.EqualTo("foo bar"));
+        }
+
         /// <summary>
         /// Using the search forward feature which doesn't hit a match in the specified path.  Should 
         /// raise a warning

--- a/VimCoreTest/Extensions.cs
+++ b/VimCoreTest/Extensions.cs
@@ -856,7 +856,7 @@ namespace Vim.UnitTest
                 result = runner.Run(command[i]);
                 if (i + 1 < command.Length)
                 {
-                    Assert.IsTrue(result.IsNeedMoreInput);
+                    Assert.IsTrue(result.IsNeedMoreInput, "Needs more input");
                 }
             }
 

--- a/VimCoreTest/VimRegexTest.cs
+++ b/VimCoreTest/VimRegexTest.cs
@@ -1070,12 +1070,20 @@ namespace Vim.UnitTest
         }
 
         /// <summary>
-        /// A \n should be able to match a tab
+        /// A \n should be able to match a newline, any newline 
         /// </summary>
         [Test]
-        public void NewLine()
+        public void NewLine_Match()
         {
-            VerifyMatches(@"\n", "hello" + Environment.NewLine);
+            VerifyMatches(@"\n", "hello\r\n", "hello\n", "hello\r");
+        }
+
+        [Test]
+        public void NewLine_Replace()
+        {
+            VerifyReplace(@"\n", "hello\nworld", " ", "hello world");
+            VerifyReplace(@"\n", "hello\r\nworld", " ", "hello world");
+            VerifyReplace(@"\n", "hello\rworld", " ", "hello world");
         }
     }
 }


### PR DESCRIPTION
To do this I had to use a non-capturing group in the regex, so one caveat
and possible future bug is that you now can't use \n in a character class
(i.e. `/bugs[\n :]are great/` will be actually be the pattern
`/bugs[(?:\r?\n|\r) :]are great/` which isn't the regex you would expect).

The fix for this would actually be a little invasive because you would
have to add some sort of `IsInsideCharacterClass` property to
`VimRegex.Data` for use in `VimRegexFactory.ProcessEscapedChar`. And
honestly, I can't think of a real fix for this (char classes don't
recognize order so `[\r\n :]` would never be meaningful). The best we could
ever do is let `\n` mean a literal `\n` when inside a character class, but
even still it wouldn't ever do what you expect.

This fixes #446 for all cases @MartinLemburg seems to be concerned with
except `^Q` (which seems like it might be a different unimplemented
feature). It also doesn't seem to break any other cases, AFAIK.
