### PR TITLE
Moved cursor out of virtual space on dedent if line is blank

### DIFF
--- a/VimCore/InsertUtil.fs
+++ b/VimCore/InsertUtil.fs
@@ -409,6 +409,9 @@ type internal InsertUtil
         let indentSpan = SnapshotLineUtil.GetIndentSpan x.CaretLine
 
         if indentSpan.Length > 0 || x.CaretVirtualPoint.IsInVirtualSpace then
+            let isBlankLine = 
+                x.CaretLine.GetText().Trim() = ""
+
             let spaces = 
                 let spaces = _operations.NormalizeBlanksToSpaces (indentSpan.GetText())
 
@@ -430,6 +433,9 @@ type internal InsertUtil
                 let spaces = spaces.Substring(0, spaces.Length - trim)
                 _operations.NormalizeBlanks spaces
             _textBuffer.Replace(indentSpan.Span, indent) |> ignore
+            if isBlankLine then
+                // the line is now all spaces, move it to the end
+                TextViewUtil.MoveCaretToPoint _textView x.CaretLine.End
 
         CommandResult.Completed ModeSwitch.NoSwitch
 

--- a/VimCoreTest/InsertUtilTest.cs
+++ b/VimCoreTest/InsertUtilTest.cs
@@ -181,8 +181,32 @@ namespace Vim.UnitTest
             Create("", "dog");
             _buffer.GlobalSettings.ShiftWidth = 4;
             _textView.MoveCaretTo(0, 8);
+
             _insertUtilRaw.ShiftLineLeft();
+
             Assert.AreEqual("    ", _textView.GetLine(0).GetText());
+            Assert.That(_insertUtilRaw.CaretColumn, Is.EqualTo(4));
+            Assert.That(_textView.Caret.InVirtualSpace, Is.False);
+            // probably redundant, but we just want to be sure...
+            Assert.That(_textView.Caret.Position.VirtualSpaces, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// This is actually non-vim behavior. Vim would leave the caret where it started, just
+        /// dedented 2 columns. I think we're opting for VS-ish behavior instead here.
+        /// </summary>
+        [Test]
+        public void ShiftLeft_CaretIsMovedToBeginningOfLineIfInVirtualSpaceAfterEndOfLine()
+        {
+            Create("    foo");
+            _buffer.GlobalSettings.ShiftWidth = 2;
+            _textView.MoveCaretTo(0, 16);
+
+            _insertUtilRaw.ShiftLineLeft();
+
+            Assert.That(_textView.GetLine(0).GetText(), Is.EqualTo("  foo"));
+            Assert.That(_insertUtilRaw.CaretColumn, Is.EqualTo(2));
+            Assert.That(_textView.Caret.Position.VirtualSpaces, Is.EqualTo(0));
         }
     }
 }


### PR DESCRIPTION
This fixes #746 by moving the caret to the end of the inserted spaces. The
previous behavior was inserting the correct amount of space, but leaving
the virtual space as well, so the cursor appeared to be extra-indented.

There is an additional change that could be made to keep the cursor at
it's "current" position - as in previous column minus dedent space. This
would be nice just because it mimicks what Vim does. But it's also nice to
not have dedent operations moving your cursor all over the place.
