### PR TITLE
Implemented `move` command

### DIFF
--- a/VimCore/Interpreter_Expression.fs
+++ b/VimCore/Interpreter_Expression.fs
@@ -211,6 +211,10 @@ and [<RequireQualifiedAccess>] LineCommand =
     /// source and the second is the desitination
     | CopyTo of LineRangeSpecifier * LineRangeSpecifier
 
+    /// Move the specific line range to the given position.  The first line range is the 
+    /// source and the second is the desitination
+    | MoveTo of LineRangeSpecifier * LineRangeSpecifier
+
     /// The :delete command
     | Delete of LineRangeSpecifier * RegisterName option
 

--- a/VimCore/Interpreter_Parser.fs
+++ b/VimCore/Interpreter_Parser.fs
@@ -74,6 +74,7 @@ type Parser
         ("join", "j")
         ("lcd", "lc")
         ("lchdir", "lch")
+        ("move", "m")
         ("make", "mak")
         ("marks", "")
         ("nohlsearch", "noh")
@@ -579,6 +580,15 @@ type Parser
         | LineRangeSpecifier.None -> ParseResult.Failed Resources.Common_InvalidAddress
         | _ -> LineCommand.CopyTo (sourceLineRange, destinationLineRange) |> ParseResult.Succeeded
 
+    /// Parse out the :copy command.  It has a single required argument that is the destination
+    /// address
+    member x.ParseMoveTo sourceLineRange = 
+        x.SkipBlanks()
+        let destinationLineRange = x.ParseLineRange()
+        match destinationLineRange with
+        | LineRangeSpecifier.None -> ParseResult.Failed Resources.Common_InvalidAddress
+        | _ -> LineCommand.MoveTo (sourceLineRange, destinationLineRange) |> ParseResult.Succeeded
+
     /// Parse out the :delete command
     member x.ParseDelete lineRange = 
         x.SkipBlanks()
@@ -741,6 +751,7 @@ type Parser
                         number
 
                 Some (LineSpecifier.LineSpecifierWithAdjustment (lineSpecifier, number))
+
             if x.IsCurrentCharValue '+' then
                 parseAdjustment false
             elif x.IsCurrentCharValue '-' then
@@ -1222,6 +1233,7 @@ type Parser
             | "marks" -> noRange x.ParseDisplayMarks
             | "map"-> noRange (fun () -> x.ParseMapKeys true [KeyRemapMode.Normal;KeyRemapMode.Visual; KeyRemapMode.Select;KeyRemapMode.OperatorPending])
             | "mapclear" -> noRange (fun () -> x.ParseMapClear true [KeyRemapMode.Normal; KeyRemapMode.Visual; KeyRemapMode.Command; KeyRemapMode.OperatorPending])
+            | "move" -> x.ParseMoveTo lineRange 
             | "nmap"-> noRange (fun () -> x.ParseMapKeys false [KeyRemapMode.Normal])
             | "nmapclear" -> noRange (fun () -> x.ParseMapClear false [KeyRemapMode.Normal])
             | "nnoremap"-> noRange (fun () -> x.ParseMapKeysNoRemap false [KeyRemapMode.Normal])

--- a/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/VimCoreTest/CommandModeIntegrationTest.cs
@@ -7,16 +7,12 @@ using Vim.UnitTest.Mock;
 
 namespace Vim.UnitTest
 {
-    /// <summary>
-    /// Summary description for CommandModeTest
-    /// </summary>
-    [TestFixture]
-    public sealed class CommandModeIntegrationTest : VimTestBase
+    public abstract class CommandModeIntegrationTestBase : VimTestBase
     {
-        private IVimBuffer _vimBuffer;
-        private ITextView _textView;
-        private MockVimHost _vimHost;
-        private string _lastStatus;
+        protected IVimBuffer _vimBuffer;
+        protected ITextView _textView;
+        protected MockVimHost _vimHost;
+        protected string _lastStatus;
 
         public void Create(params string[] lines)
         {
@@ -26,66 +22,153 @@ namespace Vim.UnitTest
             _vimHost = VimHost;
         }
 
-        private void RunCommand(string command)
+        protected void RunCommand(string command)
         {
             _vimBuffer.Process(':');
             _vimBuffer.Process(command, enter: true);
         }
 
-        /// <summary>
-        /// Copying a line to a given line should put it at that given line
-        /// </summary>
-        [Test]
-        public void CopyTo_Line()
+    }
+
+    /// <summary>
+    /// Summary description for CommandModeTest
+    /// </summary>
+    [TestFixture]
+    public sealed class CommandModeIntegrationTest : CommandModeIntegrationTestBase
+    {
+        public sealed class CopyToTests : CommandModeIntegrationTestBase
         {
-            Create("cat", "dog", "bear");
-            RunCommand("co 1");
-            Assert.AreEqual("cat", _textView.GetLine(0).GetText());
-            Assert.AreEqual("cat", _textView.GetLine(1).GetText());
-            Assert.AreEqual("dog", _textView.GetLine(2).GetText());
-            Assert.AreEqual(_textView.GetLine(1).Start, _textView.GetCaretPoint());
+            /// <summary>
+            /// Copying a line to a given line should put it at that given line
+            /// </summary>
+            [Test]
+            public void ItDisplacesToTheLineBelowWhenTargetedAtCurrentLine()
+            {
+                Create("cat", "dog", "bear");
+                RunCommand("co 1");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("cat", _textView.GetLine(1).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(2).GetText());
+                Assert.AreEqual(_textView.GetLine(1).Start, _textView.GetCaretPoint());
+            }
+
+            [Test]
+            public void ItCanJumpLongRanges()
+            {
+                Create("cat", "dog", "bear");
+                RunCommand("co 2");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(1).GetText());
+                Assert.AreEqual("cat", _textView.GetLine(2).GetText());
+                Assert.AreEqual(_textView.GetLine(2).Start, _textView.GetCaretPoint());
+            }
+
+            /// <summary>
+            /// Check the copy command via the 't' synonym
+            /// </summary>
+            [Test]
+            public void The_t_SynonymWorksAlso()
+            {
+                Create("cat", "dog", "bear");
+                RunCommand("t 2");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(1).GetText());
+                Assert.AreEqual("cat", _textView.GetLine(2).GetText());
+                Assert.AreEqual(_textView.GetLine(2).Start, _textView.GetCaretPoint());
+            }
+
+            /// <summary>
+            /// Copying a line to a range should cause it to copy to the first line 
+            /// in the range
+            /// </summary>
+            [Test]
+            public void CopyingASingleLineToARangeDuplicatesTheLine()
+            {
+                Create("cat", "dog", "bear");
+                RunCommand("co 1,2");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("cat", _textView.GetLine(1).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(2).GetText());
+            }
+
+            [Test]
+            public void PositiveRelativeReferencesUsingDotWork()
+            {
+                Create("cat", "dog", "bear");
+                _textView.MoveCaretToLine(1);
+                RunCommand("co .");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(1).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(2).GetText());
+                Assert.AreEqual("bear", _textView.GetLine(3).GetText());
+            }
+
+            [Test]
+            public void PositiveRelativeReferencesWork()
+            {
+                Create("cat", "dog", "bear");
+                RunCommand("co +1");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(1).GetText());
+                Assert.AreEqual("cat", _textView.GetLine(2).GetText());
+                Assert.AreEqual("bear", _textView.GetLine(3).GetText());
+            }
+
+            [Test]
+            public void NegativeRelativeReferencesWork()
+            {
+                // Added goose to simplify this test case. Look further for an issue with last line endlines 
+                Create("cat", "dog", "bear", "goose");
+                _textView.MoveCaretToLine(2);
+                RunCommand("co -2");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("bear", _textView.GetLine(1).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(2).GetText());
+                Assert.AreEqual("bear", _textView.GetLine(3).GetText());
+            }
+
+            [Test]
+            public void CopyingPastLastLineInsertsAnImplicitNewline()
+            {
+                Create("cat", "dog", "bear");
+                RunCommand("co 3");
+                Assert.AreEqual("cat", _textView.GetLine(0).GetText());
+                Assert.AreEqual("dog", _textView.GetLine(1).GetText());
+                Assert.AreEqual("bear", _textView.GetLine(2).GetText());
+                Assert.AreEqual("cat", _textView.GetLine(3).GetText());
+            }
+
         }
 
-        /// <summary>
-        /// Copying a line to a given line should put it at that given line
-        /// </summary>
-        [Test]
-        public void CopyTo_Line2()
+        public sealed class MoveToTests : CommandModeIntegrationTestBase
         {
-            Create("cat", "dog", "bear");
-            RunCommand("co 2");
-            Assert.AreEqual("cat", _textView.GetLine(0).GetText());
-            Assert.AreEqual("dog", _textView.GetLine(1).GetText());
-            Assert.AreEqual("cat", _textView.GetLine(2).GetText());
-            Assert.AreEqual(_textView.GetLine(2).Start, _textView.GetCaretPoint());
-        }
 
-        /// <summary>
-        /// Check the copy command via the 't' synonym
-        /// </summary>
-        [Test]
-        public void CopyTo_ViaSynonym()
-        {
-            Create("cat", "dog", "bear");
-            RunCommand("t 2");
-            Assert.AreEqual("cat", _textView.GetLine(0).GetText());
-            Assert.AreEqual("dog", _textView.GetLine(1).GetText());
-            Assert.AreEqual("cat", _textView.GetLine(2).GetText());
-            Assert.AreEqual(_textView.GetLine(2).Start, _textView.GetCaretPoint());
-        }
+            [Test]
+            public void SimpleCaseOfMovingLineOneBelow()
+            {
+                Create("cat", "dog", "bear");
 
-        /// <summary>
-        /// Copying a line to a range should cause it to copy to the first line 
-        /// in the range
-        /// </summary>
-        [Test]
-        public void CopyTo_LineRange()
-        {
-            Create("cat", "dog", "bear");
-            RunCommand("co 1,2");
-            Assert.AreEqual("cat", _textView.GetLine(0).GetText());
-            Assert.AreEqual("cat", _textView.GetLine(1).GetText());
-            Assert.AreEqual("dog", _textView.GetLine(2).GetText());
+                RunCommand("m 2");
+                Assert.That(_textView.GetLine(0).GetText(), Is.EqualTo("dog"));
+                Assert.That(_textView.GetLine(1).GetText(), Is.EqualTo("cat"));
+                Assert.That(_textView.GetLine(2).GetText(), Is.EqualTo("bear"));
+            }
+
+            /// <summary>
+            /// The last line in the file seems to be an exception because it doesn't have a 
+            /// newline at the end
+            /// </summary>
+            [Test]
+            public void MoveToLastLineInFile()
+            {
+                Create("cat", "dog", "bear");
+
+                RunCommand("m 3");
+                Assert.That(_textView.GetLine(0).GetText(), Is.EqualTo("dog"));
+                Assert.That(_textView.GetLine(1).GetText(), Is.EqualTo("bear"));
+                Assert.That(_textView.GetLine(2).GetText(), Is.EqualTo("cat"));
+            }
+
         }
 
         [Test]


### PR DESCRIPTION
Also added additional integration tests and fixed a corner case in `:copy`
where copying to the last line didn't insert a newline (and so the copied
line appeared joined with the previous line)
fixes #452
