### PR TITLE
Fixed % behavior

### DIFF
--- a/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2600,6 +2600,18 @@ namespace Vim.UnitTest
             Assert.That(_textView.GetCaretLine().LineNumber, Is.EqualTo(0));
         }
 
+        [Test]
+        public void MatchingTokens_ItMatchesEvenWhenCaretIsAtTheEnd()
+        {
+            Create("#if DEBUG", "#endif");
+            // move caret off of #if, otherwise it'll be covered by the previous functionaly and won't actually prove anything
+            _textView.MoveCaretTo(6); 
+
+            _vimBuffer.Process("%");
+
+            Assert.That(_textView.GetCaretLine().LineNumber, Is.EqualTo(1));
+        }
+
         /// <summary>
         /// Make sure we jump correctly between matching token values of different types
         ///


### PR DESCRIPTION
fixed #744

Braces worked fine because there were only open & close braces. But when you went to multi-part `#if`/`#elif`/`#else`/`#endif` it had strange nesting behavior (it believed `#elif` and `#else` were actually nested below `#if`). Also, `#ifdef` and `#ifndef` weren't implemented.
