### PR TITLE
Added #region matcher

### DIFF
--- a/VimCore/MotionUtil.fs
+++ b/VimCore/MotionUtil.fs
@@ -50,6 +50,7 @@ module internal MotionUtilLegacy =
             ("#ifdef", ["#else"; "#endif"], TokenFlags.MatchOnSeparateLine ||| TokenFlags.ValidOnlyAtStartOfLine)
             ("#ifndef", ["#else"; "#endif"], TokenFlags.MatchOnSeparateLine ||| TokenFlags.ValidOnlyAtStartOfLine)
             ("#if", ["#else"; "#elif"; "#endif"], TokenFlags.MatchOnSeparateLine ||| TokenFlags.ValidOnlyAtStartOfLine)
+            ("#region", ["#endregion"], TokenFlags.MatchOnSeparateLine ||| TokenFlags.ValidOnlyAtStartOfLine)
         ]
 
     /// Set of all of the tokens which need to be considered

--- a/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2604,6 +2604,19 @@ namespace Vim.UnitTest
         }
 
         /// <summary>
+        /// This is obviously not standard Vim behavior, but it is nice for C# developers ;)
+        /// </summary>
+        [Test]
+        public void MatchingTokens_RegionIsImplemented()
+        {
+            Create("#region DEBUG", "#endregion");
+
+            _vimBuffer.Process("%");
+
+            Assert.That(_textView.GetCaretLine().LineNumber, Is.EqualTo(1));
+        }
+
+        /// <summary>
         /// Make sure we jump correctly between matching token values of different types
         ///
         /// TODO: This test is also broken due to the matching case not being able to 


### PR DESCRIPTION
_follows #785_

Added `%` support for `#region` and `#endregion` like how `#ifdef` works. This is non-standard Vim behavior, but I think it's appropriate since VsVim is targeted at C# developers.
