### PR TITLE
Made `$` match end of line

### DIFF
--- a/VimCore/VimRegex.fs
+++ b/VimCore/VimRegex.fs
@@ -231,6 +231,13 @@ module VimRegexFactory =
                     RegexOptions.None
                 else 
                     RegexOptions.Compiled
+
+            let regexOptions = 
+                if data.IncludesNewLine then
+                    regexOptions
+                else
+                    regexOptions ||| RegexOptions.Multiline
+                    
             if data.MatchCase then
                 regexOptions
             else
@@ -260,7 +267,10 @@ module VimRegexFactory =
         | '}' -> if data.IsRangeOpen then data.EndRange() else data.AppendChar '}'
         | '|' -> data.AppendChar '|'
         | '^' -> if data.IsStartOfPattern || data.IsStartOfGrouping then data.AppendChar '^' else data.AppendEscapedChar '^'
-        | '$' -> if data.IsEndOfPattern then data.AppendChar '$' else data.AppendEscapedChar '$'
+        | '$' -> 
+            if data.IsEndOfPattern then 
+                data.AppendString @"\r?$" 
+            else data.AppendEscapedChar '$'
         | '<' -> data.AppendString @"\b"
         | '>' -> data.AppendString @"\b"
         | '[' -> data.BeginGrouping()

--- a/VimCoreTest/VimRegexTest.cs
+++ b/VimCoreTest/VimRegexTest.cs
@@ -1108,5 +1108,13 @@ namespace Vim.UnitTest
             VerifyReplace(@"\n", "hello\r\nworld", " ", "hello world");
             VerifyReplace(@"\n", "hello\rworld", " ", "hello world");
         }
+
+        [Test]
+        public void Newline_DollarSignMatchesEndOfLine()
+        {
+            VerifyMatches(@"foo$", "foo\r\nbar");
+            VerifyMatches(@"foo$", "foo\nbar");
+            VerifyMatches(@"foo$", "foo");
+        }
     }
 }


### PR DESCRIPTION
Since multiline regex option wasn't turned on, `/foo$` only matched the last
line of the file. I turned on Multiline mode and realized that `$` still
only matches `\n`, so I had to insert a `\r?` pattern before $. I can't
think of any cases that might fail this logic, and all the unit tests pass
so I'm relatively confident in the strategy.
fixes #837
