### PR TITLE
VsVimSharedTest to use NuGet for Moq

### DIFF
--- a/VsVimSharedTest/VsVimSharedTest.csproj
+++ b/VsVimSharedTest/VsVimSharedTest.csproj
@@ -105,9 +105,8 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\References\Moq.dll</HintPath>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/VsVimSharedTest/packages.config
+++ b/VsVimSharedTest/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EditorUtils" version="1.0.0.3" />
+  <package id="Moq" version="4.0.10827" />
   <package id="xunit" version="1.9.0.1566" />
 </packages>


### PR DESCRIPTION
Instead of looking for Moq in the references folder it is now provided at build time by NuGet.

Fixes #913
