### PR TITLE
Make the command line editable

### DIFF
--- a/VimWpf/Implementation/CommandMargin/CommandMargin.cs
+++ b/VimWpf/Implementation/CommandMargin/CommandMargin.cs
@@ -13,11 +13,17 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         private readonly CommandMarginControl _margin = new CommandMarginControl();
         private readonly CommandMarginController _controller;
 
-        public CommandMargin(IVimBuffer buffer, IEditorFormatMap editorFormatMap, IEnumerable<Lazy<IOptionsProviderFactory>> optionsProviderFactories)
-        {
-            _margin.StatusLine = "Welcome to Vim";
-            _controller = new CommandMarginController(buffer, _margin, editorFormatMap, optionsProviderFactories);
-        }
+		public CommandMargin(IVimBuffer buffer, IEditorFormatMap editorFormatMap, IEnumerable<Lazy<IOptionsProviderFactory>> optionsProviderFactories)
+			: this(null, buffer, editorFormatMap, optionsProviderFactories)
+		{
+		}
+
+		public CommandMargin(FrameworkElement parentVisualElement, IVimBuffer buffer, IEditorFormatMap editorFormatMap, IEnumerable<Lazy<IOptionsProviderFactory>> optionsProviderFactories)
+		{
+			_margin.StatusLine = "Welcome to Vim";
+			_controller = new CommandMarginController(buffer, _margin, editorFormatMap, optionsProviderFactories);
+			_controller.ParentVisualElement = parentVisualElement;
+		}
 
         public FrameworkElement VisualElement
         {

--- a/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml
+++ b/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml
@@ -39,12 +39,16 @@
             />
 
         <TextBox 
+            x:Name="commandLineInput"
             Grid.Row="0"
             Grid.Column="1"
             Text="{Binding Path=StatusLine}" 
-            IsReadOnly="True"
+            IsReadOnly="{Binding Path=IsCommandEditionDisable}"
             Foreground="{Binding Path=TextForeground}"
             Background="{Binding Path=TextBackground}"
+            PreviewKeyDown="commandLineInput_PreviewKeyDown"
+            TextChanged="commandLineInput_TextChanged"
+            SelectionChanged="commandLineInput_SelectionChanged"
             />
 
         <Button

--- a/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml.cs
+++ b/VimWpf/Implementation/CommandMargin/CommandMarginControl.xaml.cs
@@ -7,11 +7,21 @@ using System.Windows.Media;
 namespace Vim.UI.Wpf.Implementation.CommandMargin
 {
     /// <summary>
+    /// CommandMargin event data 
+    /// </summary>
+	public class CommandMarginEventArgs : EventArgs
+	{
+		public string Command { get; set; }
+	}
+
+    /// <summary>
     /// Interaction logic for CommandMarginControl.xaml
     /// </summary>
     public partial class CommandMarginControl : UserControl
     {
-        public static readonly DependencyProperty StatusLineProperty = DependencyProperty.Register(
+		private bool _isEditDisable = true;
+
+		public static readonly DependencyProperty StatusLineProperty = DependencyProperty.Register(
             "StatusLine", 
             typeof(string),
             typeof(CommandMarginControl));
@@ -20,6 +30,12 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             "IsRecording", 
             typeof(Visibility),
             typeof(CommandMarginControl));
+
+		public static readonly DependencyProperty IsCommandEditionDisableProperty = DependencyProperty.Register(
+			"IsCommandEditionDisable",
+			typeof(bool),
+			typeof(CommandMarginControl),
+			new PropertyMetadata(true));
 
         public static readonly DependencyProperty TextForegroundProperty = DependencyProperty.Register(
             "TextForeground",
@@ -42,6 +58,12 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             set { SetValue(StatusLineProperty, value); }
         }
 
+		public bool IsCommandEditionDisable
+		{
+			get { return (bool)GetValue(IsCommandEditionDisableProperty); }
+			set { _isEditDisable = value; SetValue(IsCommandEditionDisableProperty, value); }
+		}
+
         public Visibility IsRecording
         {
             get { return (Visibility) GetValue(IsRecordingProperty); }
@@ -60,7 +82,11 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             set { SetValue(TextBackgroundProperty, value); }
         }
 
-        public event EventHandler OptionsClicked;
+		public event EventHandler OptionsClicked;
+		public event EventHandler CancelCommandEdition;
+		public event EventHandler RunCommandEdition;
+		public event EventHandler HistoryGoPrevious;
+		public event EventHandler HistoryGoNext;
 
         public CommandMarginControl()
         {
@@ -80,5 +106,130 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
                 savedEvent(this, EventArgs.Empty);
             }
         }
+
+		public void FocusCommandLine(bool moveCaretToEnd)
+		{
+			commandLineInput.Focus();
+
+			UpdateCaretPosition(moveCaretToEnd);
+		}
+
+		public void UpdateCaretPosition(bool moveToEnd)
+		{
+			if (commandLineInput.IsFocused) // We also use this when navigation through history
+			{
+				var l = commandLineInput.Text.Length;
+				commandLineInput.Select(
+					moveToEnd ?
+						l :		            // Move caret to the last character 
+						Math.Min(l, 1),     // Move caret after the command prefix
+					0);
+			}
+		}
+
+		private void DoCancelCommandEdition()
+		{
+			var savedEvent = CancelCommandEdition;
+			if (savedEvent != null)
+			{
+				savedEvent(this, EventArgs.Empty);
+			}
+		}
+
+		private void DoHistoryGoPrevious()
+		{
+			var savedEvent = HistoryGoPrevious;
+			if (savedEvent != null)
+			{
+				savedEvent(this, EventArgs.Empty);
+			}
+		}
+
+		private void DoHistoryGoNext()
+		{
+			var savedEvent = HistoryGoNext;
+			if (savedEvent != null)
+			{
+				savedEvent(this, EventArgs.Empty);
+			}
+		}
+
+		private void DoRunCommandEdition(string command)
+		{
+			var savedEvent = RunCommandEdition;
+			if (savedEvent != null)
+			{
+				var evArgs = new EventArgs();
+				savedEvent(this, new CommandMarginEventArgs() { Command = commandLineInput.Text });
+			}
+		}
+
+		private void commandLineInput_PreviewKeyDown(object sender, KeyEventArgs e)
+		{
+			switch (e.Key)
+			{
+				case Key.Escape:
+					DoCancelCommandEdition();
+					break;
+
+				case Key.Return:
+					DoRunCommandEdition(commandLineInput.Text.Trim());
+					break;
+
+				case Key.Up:
+					DoHistoryGoPrevious();
+					break;
+
+				case Key.Down:
+					DoHistoryGoNext();
+					break;
+
+				case Key.Back:
+					if (commandLineInput.Text.Trim().Length > 1)
+					{
+						// Prevent erasing the command prefix, unless it is the only character
+						if (1 == commandLineInput.CaretIndex)
+							e.Handled = true;
+					}
+					break;
+			}
+		}
+
+		private void commandLineInput_TextChanged(object sender, TextChangedEventArgs e)
+		{
+			if (!_isEditDisable && 0 == commandLineInput.Text.Trim().Length)
+			{
+				DoCancelCommandEdition();
+			}
+		}
+
+		private void commandLineInput_SelectionChanged(object sender, RoutedEventArgs e)
+		{
+			if (commandLineInput.Text.Length > 0)
+			{
+				// Prevent modifications to the command prefix
+				var sl = commandLineInput.SelectionLength;
+
+				if (sl > 0)
+				{
+					if (0 == commandLineInput.SelectionStart)
+					{
+						commandLineInput.CaretIndex = 1;
+						commandLineInput.SelectionStart = 1;
+						commandLineInput.SelectionLength = sl - 1;
+					}
+					else
+					{
+						if (0 == commandLineInput.CaretIndex)
+							commandLineInput.CaretIndex = 1;
+					}
+				}
+				else
+				{
+					if (0 == commandLineInput.CaretIndex)
+						commandLineInput.CaretIndex = 1;
+				}
+			}
+		}
     }
 }

--- a/VimWpf/Implementation/CommandMargin/CommandMarginProvider.cs
+++ b/VimWpf/Implementation/CommandMargin/CommandMarginProvider.cs
@@ -38,7 +38,7 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         {
             var buffer = _vim.GetOrCreateVimBuffer(wpfTextViewHost.TextView);
             var editorFormatMap = _editorFormatMapService.GetEditorFormatMap(wpfTextViewHost.TextView);
-            return new CommandMargin(buffer, editorFormatMap, _optionsProviderFactories);
+			return new CommandMargin(wpfTextViewHost.TextView.VisualElement, buffer, editorFormatMap, _optionsProviderFactories);
         }
     }
 }


### PR DESCRIPTION
The user can now edit the command line (when inputting commands or making a search).
- This can be done by either:
  -  clicking the command line;
  -  pressing ARROW LEFT (goes to the end);
  -  pressing HOME (goes to the beginning).
- The edition can be terminated by:
  - pressing ESC,
  - deleting everything (BACKSPACE)
  - executed by pressing RETURN
- Since the command line is just a regular textbox, clipboard access becomes a handy bonus ;)

Signed-off-by: Antonio Inacio ja.te.disse@hotmail.com
