### PR TITLE
Add support for ReSharper 8.1

### DIFF
--- a/Src/VsVimShared/Implementation/Resharper/ReSharperVersion.cs
+++ b/Src/VsVimShared/Implementation/Resharper/ReSharperVersion.cs
@@ -5,5 +5,6 @@
         Unknown,
         Version7AndEarlier,
         Version8,
+        Version81
     }
 }

--- a/Src/VsVimShared/Implementation/Resharper/ResharperExternalEditAdapter.cs
+++ b/Src/VsVimShared/Implementation/Resharper/ResharperExternalEditAdapter.cs
@@ -67,6 +67,9 @@ namespace VsVim.Implementation.ReSharper
                 case ReSharperVersion.Version8:
                     _reSharperEditTagDetector = new ReSharperV8EditTagDetector();
                     break;
+                case ReSharperVersion.Version81:
+                    _reSharperEditTagDetector = new ReSharperV81EditTagDetector();
+                    break;
                 case ReSharperVersion.Unknown:
                     _reSharperEditTagDetector = new ReSharperUnknownEditTagDetector();
                     break;

--- a/Src/VsVimShared/Implementation/Resharper/ResharperVersionutility.cs
+++ b/Src/VsVimShared/Implementation/Resharper/ResharperVersionutility.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace VsVim.Implementation.ReSharper
 {
@@ -19,25 +21,32 @@ namespace VsVim.Implementation.ReSharper
         /// </summary>
         internal const string ResharperAssemblyNameV8 = "JetBrains.Platform.ReSharper.VisualStudio.SinceVs10";
 
-        internal static ReSharperVersion DetectFromAssemblyName(string assemblyFullName)
+        internal static ReSharperVersion DetectFromAssembly(Assembly assembly)
         {
-            if (assemblyFullName.StartsWith(ResharperAssemblyNameV8))
+            if (assembly.FullName.StartsWith(ResharperAssemblyNameV8))
             {
-                return ReSharperVersion.Version8;
-            }
+                FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+                var version = new Version(fvi.FileVersion);
 
-            if (assemblyFullName.StartsWith(ResharperAssemblyName2010) ||
-                assemblyFullName.StartsWith(ResharperAssemblyName2012))
+                if (version.Major == 8)
+                {
+                    switch (version.Minor)
+                    {
+                        case 0:
+                            return ReSharperVersion.Version8;
+                        case 1:
+                            return ReSharperVersion.Version81;
+                    }
+                }
+                return ReSharperVersion.Unknown;
+            }
+            if (assembly.FullName.StartsWith(ResharperAssemblyName2010) ||
+                assembly.FullName.StartsWith(ResharperAssemblyName2012))
             {
                 return ReSharperVersion.Version7AndEarlier;
             }
 
             return ReSharperVersion.Unknown;
-        }
-
-        internal static ReSharperVersion DetectFromAssembly(Assembly assembly)
-        {
-            return DetectFromAssemblyName(assembly.FullName);
         }
     }
 }


### PR DESCRIPTION
Adds Version81 to ReSharperVersion enum.
Detects assembly version through FileVersionInfo (same assembly name as ReSharper 8.0).
Reuses Tag detection logic from ReSharperV7EditTagDetector (could refactor to share code since only diff is field name).
