### PR TITLE
Scroll by half of the size of the text view, not half of the number of visible lines.

### DIFF
--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -542,19 +542,7 @@ type internal WindowSettings
         let defaultValue = 10
         match _textView with
         | None -> defaultValue
-        | Some textView ->
-            try
-                let col = textView.TextViewLines
-                match col.FirstVisibleLine,col.LastVisibleLine with
-                | (null, _) -> defaultValue
-                | (_, null) -> defaultValue
-                | (top, bottom) ->
-                    let topLine = top.Start.GetContainingLine()
-                    let endLine = bottom.End.GetContainingLine()
-                    (endLine.LineNumber - topLine.LineNumber) / 2
-            with 
-                // This will be thrown if we're currently in the middle of an inner layout
-                :? System.InvalidOperationException -> defaultValue
+        | Some textView -> int (textView.ViewportHeight / textView.LineHeight / 2.0 + 0.5)
 
     static member Copy (settings : IVimWindowSettings) = 
         let copy = WindowSettings(settings.GlobalSettings)


### PR DESCRIPTION
Vim's half-screen scrolling commands (`Ctrl+D`, `Ctrl+U`) do not depend on how many lines are actually displayed but on how big the screen is.  VsVim uses the number of lines actually displayed, which is incorrect when fewer lines are displayed than can fit on the screen.

Steps to reproduce:
- Assume the screen fits 40 lines.
- Create a text file that has 45 lines.
- Open the text file in Visual Studio.
- Issue the `Ctrl+F` command to page forward.
- The last five lines of the file are displayed at the top of the window.
- Press `Ctrl+U` to page up by half a screen.
- Notice that the caret has only been moved up 2 lines, instead of 20.
