### PR TITLE
Fix conversion from font size in points to pixels.

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3607,8 +3607,10 @@ type FontPropertiesEventArgs () =
 
 type IFontProperties =
 
+    /// The font family
     abstract FontFamily : System.Windows.Media.FontFamily
 
+    /// The font size in points
     abstract FontSize : double
 
     [<CLIEvent>]

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -314,23 +314,9 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
         private void UpdateFontProperties()
         {
             _margin.TextFontFamily = _fontProperties.FontFamily;
-            _margin.TextFontSize = _fontProperties.FontSize * GetDpiScaling();
-        }
 
-        /// <summary>
-        /// Get the DPI scaling factor for the control.
-        /// </summary>
-        /// <returns></returns>
-        private double GetDpiScaling()
-        {
-            var source = PresentationSource.FromVisual(_margin);
-            if (source != null)
-            {
-                var dpiX = 96 * source.CompositionTarget.TransformToDevice.M11;
-                var dpiY = 96 * source.CompositionTarget.TransformToDevice.M22;
-                return (dpiX + dpiY) / 2 / 96;
-            }
-            return 1;
+            // Convert points (1 pt = 1/72") to pixels (1 WPF pixel = 1/96").
+            _margin.TextFontSize = _fontProperties.FontSize * 96 / 72;
         }
 
         /// <summary>


### PR DESCRIPTION
Referencing [this](https://github.com/jaredpar/VsVim/pull/1218#issuecomment-31581114) comment.

I think I found the problem.  Visual Studio specifies the font size in points and the `FontSize` property in WPF is in pixels (see [this](http://stackoverflow.com/questions/3444371/converting-between-wpf-font-size-and-standard-font-size) StackOverflow question).

I had falsely assumed that the discrepancy I was seeing was due to the fact that I use 120 DPI (125%) instead of the default 96 DPI (100%).  However, the difference is actually due to the units, not DPI scaling.

For reference, here are new screenshots tested with Consolas 10 at both 96 DPI and 120 DPI.

96 DPI:
![image](https://f.cloud.github.com/assets/2680524/1845396/150d47e2-7586-11e3-94bb-ba07e791b739.png)

120 DPI:
![image](https://f.cloud.github.com/assets/2680524/1845397/1b160d0e-7586-11e3-8064-bd76e6c52727.png)
