### PR TITLE
Let host insert the newline when replacing characters

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2002,7 +2002,7 @@ type internal CommandUtil
         let point = x.CaretPoint
         let line = point.GetContainingLine()
 
-        let ReplaceChar () =
+        let replaceChar () =
             let span = new Span(point.Position, count)
             let position =
                 if keyInput = KeyInputUtil.EnterKey then 
@@ -2046,7 +2046,7 @@ type internal CommandUtil
         else
             // Do the replace in an undo transaction since we are explicitly positioning
             // the caret
-            x.EditWithUndoTransaciton "ReplaceChar" (fun () -> ReplaceChar())
+            x.EditWithUndoTransaciton "ReplaceChar" (fun () -> replaceChar())
             CommandResult.Completed ModeSwitch.NoSwitch
 
     /// Replace the char under the cursor in visual mode.


### PR DESCRIPTION
Ideally, issuing `r<Enter>` in normal mode would have the same effect as issuing `s<Enter><Esc>`.  Currently, this behaves differently if the host performs some magic while inserting the `<Enter>`, e.g. while editing documentation comments in C#.

When replacing characters using `r` with the `Enter` key, this change lets the host perform the insertion.  Although the code that performs the `ReplaceChar` operation has been reorganized, the logic for the case where the replacement character is not `Enter` has not changed.  There are already tests for both cases and they still pass.

Example for C# content:

``` csharp
/// <summary>
/// cat dog
/// </summary>
```

Issue `r<Enter>` on the space between `cat` and `dog`:

``` csharp
/// <summary>
/// cat
/// dog
/// </summary>
```
