### PR TITLE
Fix text view holding onto vim buffer

### DIFF
--- a/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessor.cs
+++ b/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessor.cs
@@ -36,7 +36,6 @@ namespace VsVim.Implementation.Misc
         private readonly _DTE _dte;
         private readonly IKeyUtil _keyUtil;
         private readonly IVimApplicationSettings _vimApplicationSettings;
-        private readonly IVimBuffer _vimBuffer;
 
         private List<FallbackCommand> _fallbackCommandList;
 
@@ -45,12 +44,11 @@ namespace VsVim.Implementation.Misc
         /// by not making use of it, the fallback processor can be reused for
         /// multiple text views
         /// </summary>
-        internal FallbackKeyProcessor(_DTE dte, IKeyUtil keyUtil, IVimApplicationSettings vimApplicationSettings, IVimBuffer vimBuffer)
+        internal FallbackKeyProcessor(_DTE dte, IKeyUtil keyUtil, IVimApplicationSettings vimApplicationSettings)
         {
             _dte = dte;
             _keyUtil = keyUtil;
             _vimApplicationSettings = vimApplicationSettings;
-            _vimBuffer = vimBuffer;
             _fallbackCommandList = new List<FallbackCommand>();
 
             // Register for key binding changes and get the current bindings
@@ -176,13 +174,6 @@ namespace VsVim.Implementation.Misc
         /// </summary>
         internal bool TryProcess(KeyInput keyInput)
         {
-            // If this processor is associated with a IVimBuffer then don't fall back to VS commands 
-            // unless vim is currently disabled
-            if (_vimBuffer != null && _vimBuffer.ModeKind != ModeKind.Disabled)
-            {
-                return false;
-            }
-
             // Check for any applicable fallback bindings, in order
             VimTrace.TraceInfo("FallbackKeyProcessor::TryProcess {0}", keyInput);
             foreach (var fallbackCommand in _fallbackCommandList)

--- a/Src/VsVimShared/Implementation/Misc/VsKeyProcessorProvider.cs
+++ b/Src/VsVimShared/Implementation/Misc/VsKeyProcessorProvider.cs
@@ -15,6 +15,7 @@ namespace VsVim.Implementation.Misc
     [ContentType(Vim.Constants.ContentType)]
     internal sealed class VsKeyProcessorProvider : IKeyProcessorProvider
     {
+        private readonly FallbackKeyProcessorProvider _fallbackKeyProcessorProvider;
         private readonly IVimBufferCoordinatorFactory _bufferCoordinatorFactory;
         private readonly IVsAdapter _adapter;
         private readonly IVim _vim;
@@ -22,13 +23,14 @@ namespace VsVim.Implementation.Misc
         private readonly IReportDesignerUtil _reportDesignerUtil;
 
         [ImportingConstructor]
-        internal VsKeyProcessorProvider(IVim vim, IVsAdapter adapter, IVimBufferCoordinatorFactory bufferCoordinatorFactory, IKeyUtil keyUtil, IReportDesignerUtil reportDesignerUtil)
+        internal VsKeyProcessorProvider(IVim vim, IVsAdapter adapter, IVimBufferCoordinatorFactory bufferCoordinatorFactory, IKeyUtil keyUtil, IReportDesignerUtil reportDesignerUtil, FallbackKeyProcessorProvider fallbackKeyProcessorProvider)
         {
             _vim = vim;
             _adapter = adapter;
             _bufferCoordinatorFactory = bufferCoordinatorFactory;
             _keyUtil = keyUtil;
             _reportDesignerUtil = reportDesignerUtil;
+            _fallbackKeyProcessorProvider = fallbackKeyProcessorProvider;
         }
 
         KeyProcessor IKeyProcessorProvider.GetAssociatedProcessor(IWpfTextView wpfTextView)
@@ -39,8 +41,9 @@ namespace VsVim.Implementation.Misc
                 return null;
             }
 
+            var fallbackKeyProcessor = _fallbackKeyProcessorProvider.GetOrCreateFallbackProcessor(wpfTextView);
             var vimBufferCoordinator = _bufferCoordinatorFactory.GetVimBufferCoordinator(vimBuffer);
-            return new VsKeyProcessor(_adapter, vimBufferCoordinator, _keyUtil, _reportDesignerUtil, wpfTextView);
+            return new VsKeyProcessor(fallbackKeyProcessor, _adapter, vimBufferCoordinator, _keyUtil, _reportDesignerUtil, wpfTextView);
         }
     }
 }

--- a/Test/VsVimSharedTest/Utils/VsSimulation.cs
+++ b/Test/VsVimSharedTest/Utils/VsSimulation.cs
@@ -366,7 +366,7 @@ namespace VsVim.UnitTest.Utils
             {
                 _vsKeyboardInputSimulation.KeyProcessors.Add(ReSharperKeyUtil.GetOrCreate(bufferCoordinator));
             }
-            _vsKeyboardInputSimulation.KeyProcessors.Add(new VsKeyProcessor(_vsAdapter.Object, bufferCoordinator, _keyUtil, _reportDesignerUtil.Object, _wpfTextView));
+            _vsKeyboardInputSimulation.KeyProcessors.Add(new VsKeyProcessor(null, _vsAdapter.Object, bufferCoordinator, _keyUtil, _reportDesignerUtil.Object, _wpfTextView));
             _vsKeyboardInputSimulation.KeyProcessors.Add((KeyProcessor)bufferCoordinator);
             _vsKeyboardInputSimulation.KeyProcessors.Add(new SimulationKeyProcessor(bufferCoordinator.VimBuffer.TextView));
         }

--- a/Test/VsVimSharedTest/VsKeyProcessorTest.cs
+++ b/Test/VsVimSharedTest/VsKeyProcessorTest.cs
@@ -249,7 +249,7 @@ namespace VsVim.UnitTest
             _mockVimBuffer.SetupGet(x => x.ModeKind).Returns(ModeKind.Normal);
             _bufferCoordinator = new VimBufferCoordinator(_mockVimBuffer.Object);
             _device = new MockKeyboardDevice();
-            return new VsKeyProcessor(_vsAdapter.Object, _bufferCoordinator, KeyUtil, _reportDesignerUtil.Object, _wpfTextView);
+            return new VsKeyProcessor(null, _vsAdapter.Object, _bufferCoordinator, KeyUtil, _reportDesignerUtil.Object, _wpfTextView);
         }
 
         public sealed class VsKeyDownTest : VsKeyProcessorTest


### PR DESCRIPTION
The changes for fixing #925 introduced failures in the memory leak integration tests because the fallback processor retains a reference to its corresponding vim buffer.

This change fixes those test failures by arranging for text view key processors that correspond with vim buffers to coordinate their actions directly with the fallback processor.  All other text view processors use the fallback key processor unconditionally.  As a result, the fallback key processor itself no longer needs a reference to the vim buffer.
