### PR TITLE
Fix regression in handling of text editor key bindings

### DIFF
--- a/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessor.cs
+++ b/Src/VsVimShared/Implementation/Misc/FallbackKeyProcessor.cs
@@ -102,7 +102,14 @@ namespace VsVim.Implementation.Misc
         /// </summary>
         private bool IsTextViewBinding(CommandKeyBinding binding)
         {
-            return _scopeData.GetScopeKind(binding.KeyBinding.Scope) != ScopeKind.Unknown;
+            switch (_scopeData.GetScopeKind(binding.KeyBinding.Scope))
+            {
+                case ScopeKind.TextEditor:
+                case ScopeKind.Global:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         /// <summary>
@@ -111,7 +118,15 @@ namespace VsVim.Implementation.Misc
         /// </summary>
         private int GetScopeOrder(string scope)
         {
-            return (int)_scopeData.GetScopeKind(scope);
+            switch (_scopeData.GetScopeKind(scope))
+            {
+                case ScopeKind.TextEditor:
+                    return 1;
+                case ScopeKind.Global:
+                    return 2;
+                default:
+                    throw new InvalidOperationException("Unexpected ScopeKind");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Restore correct filtering and ordering of fallback key bindings.
- Only TextEditor and Global bindings are applicable to to IWpfTextView instancees
- TextEditor bindings should be prioritized before Global bindings

The recent `FallbackKeyProcessor` cleanup to address localization of Visual Studio scope names introduced a regression in which global bindings are considered before text editor bindings.  As a result, `Shift+Left` no longer works in the immediate window or when VsVim is disabled, but instead issues a command which throws the COM exception:

```
"The Command to execute is not enabled"
```
