### PR TITLE
Fixes 1266

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1855,7 +1855,7 @@ type internal CommandUtil
         _macroRecorder.StopRecording()
         CommandResult.Completed ModeSwitch.NoSwitch
 
-    /// Undo count operations in the ITextBuffer
+    /// Redo count operations in the ITextBuffer
     member x.Redo count = 
         _commonOperations.Redo count
         CommandResult.Completed ModeSwitch.NoSwitch

--- a/Src/VimCore/UndoRedoOperations.fs
+++ b/Src/VimCore/UndoRedoOperations.fs
@@ -149,6 +149,7 @@ and UndoRedoOperations
             let head, tail = 
                 match head with
                 | UndoRedoData.Normal c -> UndoRedoData.Normal (count + c), tail
+                | UndoRedoData.Linked 0 -> UndoRedoData.Normal count, tail
                 | UndoRedoData.Linked _ -> UndoRedoData.Normal count, list
             head :: tail 
 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -2546,7 +2546,7 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
-            /// When a 'cw' command is repeated once with '.', 'uu' shoudl undo both
+            /// When a 'cw' command is repeated once with '.', 'uu' should undo both
             /// </summary>
             [Fact]
             public void Issue1266()


### PR DESCRIPTION
When pushing onto the undo stack, elide zero-length entries

A redo that consists of a tree of three or more linked commands (like `cw`) can create a zero-length `UndoRedoData.Linked` entry in the undo stack.  Allow this to happen but correct for it when pushing the next normal entry.

Closes #1266
