### PR TITLE
Fixes 1269

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -178,6 +178,7 @@ type internal CommonOperations
     member x.AdjustCaretForVirtualEdit() =
 
         let allowPastEndOfLine = 
+            _vimTextBuffer.ModeKind = ModeKind.Insert ||
             _globalSettings.IsVirtualEditOneMore ||
             (_globalSettings.SelectionKind = SelectionKind.Exclusive && VisualKind.IsAnyVisualOrSelect _vimTextBuffer.ModeKind)
 

--- a/Src/VimCore/InsertUtil.fsi
+++ b/Src/VimCore/InsertUtil.fsi
@@ -6,7 +6,7 @@ open Microsoft.VisualStudio.Text.Outlining
 
 type internal InsertUtil =
 
-    new : IVimBufferData * ICommonOperations -> InsertUtil
+    new : IVimBufferData * IMotionUtil * ICommonOperations -> InsertUtil
 
     interface IInsertUtil
 

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -233,7 +233,7 @@ type internal VimBufferFactory
         let textChangeTracker = _textChangeTrackerFactory.GetTextChangeTracker vimBufferData
         let motionUtil = MotionUtil(vimBufferData, commonOperations) :> IMotionUtil
         let foldManager = _foldManagerFactory.GetFoldManager textView
-        let insertUtil = InsertUtil(vimBufferData, commonOperations) :> IInsertUtil
+        let insertUtil = InsertUtil(vimBufferData, motionUtil, commonOperations) :> IInsertUtil
         let commandUtil = CommandUtil(vimBufferData, motionUtil, commonOperations, foldManager, insertUtil, _bulkOperations, _mouseDevice) :> ICommandUtil
 
         let bufferRaw = VimBuffer(vimBufferData, incrementalSearch, motionUtil, wordNav, vimBufferData.WindowSettings, commandUtil)

--- a/Test/VimCoreTest/CommandUtilTest.cs
+++ b/Test/VimCoreTest/CommandUtilTest.cs
@@ -65,7 +65,7 @@ namespace Vim.UnitTest
                 _motionUtil,
                 operations,
                 foldManager,
-                new InsertUtil(vimBufferData, operations),
+                new InsertUtil(vimBufferData, _motionUtil, operations),
                 _bulkOperations,
                 MouseDevice);
 

--- a/Test/VimCoreTest/InsertUtilTest.cs
+++ b/Test/VimCoreTest/InsertUtilTest.cs
@@ -33,7 +33,8 @@ namespace Vim.UnitTest
             _localSettings = _vimBuffer.LocalSettings;
 
             var operations = CommonOperationsFactory.GetCommonOperations(_vimBuffer.VimBufferData);
-            _insertUtilRaw = new InsertUtil(_vimBuffer.VimBufferData, operations);
+            var motionUtil = new MotionUtil(_vimBuffer.VimBufferData, operations);
+            _insertUtilRaw = new InsertUtil(_vimBuffer.VimBufferData, motionUtil, operations);
             _insertUtil = _insertUtilRaw;
         }
 
@@ -550,7 +551,7 @@ namespace Vim.UnitTest
 
                 _insertUtilRaw.MoveCaretByWord(Direction.Right);
 
-                Assert.Equal(3, _textView.GetCaretPoint().Position);
+                Assert.Equal(2, _textView.GetCaretPoint().Position);
             }
 
             /// <summary>

--- a/Test/VimCoreTest/VimTestBase.cs
+++ b/Test/VimCoreTest/VimTestBase.cs
@@ -353,7 +353,7 @@ namespace Vim.UnitTest
             motionUtil = motionUtil ?? new MotionUtil(vimBufferData, operations);
             operations = operations ?? CommonOperationsFactory.GetCommonOperations(vimBufferData);
             foldManager = foldManager ?? VimUtil.CreateFoldManager(vimBufferData.TextView, vimBufferData.StatusUtil);
-            insertUtil = insertUtil ?? new InsertUtil(vimBufferData, operations);
+            insertUtil = insertUtil ?? new InsertUtil(vimBufferData, motionUtil, operations);
             return new CommandUtil(
                 vimBufferData,
                 motionUtil,


### PR DESCRIPTION
Rewrite motion by word in insert-mode to use motion infrastructure
- Make motion utilities usable by insert utilties
- Use them in `MoveCaretByWord` instead of word utilities
- Adjust unit test scaffolding for API changes
- Allow insert mode to bypass `virtualedit` adjustment
- Swap expected/actual arguments to match usage in related tests
- Add unit tests for issue #1269

Closes #1269.
