### PR TITLE
Add Ctrl+A to select mode and fix undo replacing selection

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2355,6 +2355,7 @@ type internal CommandUtil
         | VisualCommand.CutSelection -> x.CutSelection streamSelectionSpan
         | VisualCommand.CopySelection -> x.CopySelection streamSelectionSpan
         | VisualCommand.CutSelectionAndPaste -> x.CutSelectionAndPaste streamSelectionSpan
+        | VisualCommand.SelectAll -> x.SelectAll()
 
     /// Get the MotionResult value for the provided MotionData and pass it
     /// if found to the provided function
@@ -2920,6 +2921,11 @@ type internal CommandUtil
         _textView.Selection.Select(streamSelectionSpan.Start, streamSelectionSpan.End)
         _editorOperations.Paste() |> ignore
         CommandResult.Completed ModeSwitch.SwitchPreviousMode
+
+    /// Select the whole document
+    member x.SelectAll () =
+        _textView.Selection.Select(_textBuffer.CurrentSnapshot.GetExtent(), false)
+        CommandResult.Completed ModeSwitch.NoSwitch
 
     interface ICommandUtil with
         member x.RunNormalCommand command data = x.RunNormalCommand command data

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -2674,6 +2674,9 @@ type VisualCommand =
     /// Cut selection and paste
     | CutSelectionAndPaste
 
+    /// Select the whole document
+    | SelectAll
+
 /// Insert mode commands that can be executed by the user
 [<RequireQualifiedAccess>]
 [<NoComparison>]

--- a/Test/VimCoreTest/SelectModeIntegrationTest.cs
+++ b/Test/VimCoreTest/SelectModeIntegrationTest.cs
@@ -715,6 +715,21 @@ namespace Vim.UnitTest
                 Assert.Equal("cat bear", _textBuffer.GetLine(0).GetText());
                 Assert.Equal(0, _textView.GetCaretPoint().Position);
             }
+
+            /// <summary>
+            /// The initial replacement and any subsequent insert mode input should be linked
+            /// into a single undo
+            /// </summary>
+            [Fact]
+            public void UndoAfterMultipleInputChars()
+            {
+                Create("dog cat bear");
+                EnterSelect(4, 4);
+                _vimBuffer.ProcessNotation("and <Esc>");
+                Assert.Equal("dog and bear", _textBuffer.GetLine(0).GetText());
+                _vimBuffer.ProcessNotation("u");
+                Assert.Equal("dog cat bear", _textBuffer.GetLine(0).GetText());
+            }
         }
 
         public sealed class KeyMovementCharacter : SelectModeIntegrationTest


### PR DESCRIPTION
- Map `Ctrl+A` in select mode to "Select All" command
- Link selection replacement to the subsequent insert mode so that undo undoes the whole replacement
