### PR TITLE
Use native caret height for VsVim caret height

### DIFF
--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -270,12 +270,11 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         private Size CalculateCaretSize()
         {
             double defaultWidth = FormattedText.Width;
-            double defaultHeight = FormattedText.Height;
 
             var caret = _textView.Caret;
             var line = caret.ContainingTextViewLine;
             double width = defaultWidth;
-            double height = line.IsValid ? line.Height : defaultHeight;
+            double height = caret.Height;
             if (IsRealCaretVisible)
             {
                 // Get the size of the character to which we need to paint the caret.  Special case


### PR DESCRIPTION
Instead of trying to compute what the correct caret height should be for a given point, we can just use the native text editor's caret height.  Although it's not the caret we want, it is sure to be the height we want to use.

I'm not sure it can be this easy but it seems to work fine for "normal" fixed-font buffers, Code Lens lines, and variable font buffers ([Markdown Mode](https://github.com/NoahRic/MarkdownMode) is a good test).  I was unable to repro the peek definition problem but that seems to work fine as well.

Fixes #1242.

![image](https://f.cloud.github.com/assets/2680524/2106937/fee19ee4-8fb8-11e3-9af0-f316d5375f2e.png)
