### PR TITLE
Handle active selection after being disabled

### DIFF
--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -636,18 +636,31 @@ type internal Vim
         | None ->
             false
 
+    member x.DisableVimBuffer (vimBuffer : IVimBuffer) =
+        vimBuffer.SwitchMode ModeKind.Disabled ModeArgument.None |> ignore
+
+    member x.EnableVimBuffer (vimBuffer : IVimBuffer) =
+        let modeKind =
+            if vimBuffer.TextView.Selection.IsEmpty then
+                ModeKind.Normal
+            elif Util.IsFlagSet _globalSettings.SelectModeOptions SelectModeOptions.Mouse then
+                ModeKind.SelectCharacter
+            else
+                ModeKind.VisualCharacter
+        vimBuffer.SwitchMode modeKind ModeArgument.None |> ignore
+
     /// Toggle disabled mode for all active IVimBuffer instances to sync up with the current
     /// state of _isDisabled
     member x.UpdatedDisabledMode() = 
         if _isDisabled then
             x.VimBuffers
             |> Seq.filter (fun vimBuffer -> vimBuffer.Mode.ModeKind <> ModeKind.Disabled)
-            |> Seq.iter (fun vimBuffer -> vimBuffer.SwitchMode ModeKind.Disabled ModeArgument.None |> ignore)
+            |> Seq.iter x.DisableVimBuffer
 
         else
             x.VimBuffers
             |> Seq.filter (fun vimBuffer -> vimBuffer.Mode.ModeKind = ModeKind.Disabled)
-            |> Seq.iter (fun vimBuffer -> vimBuffer.SwitchMode ModeKind.Normal ModeArgument.None |> ignore)
+            |> Seq.iter x.EnableVimBuffer
 
     interface IVim with
         member x.ActiveBuffer = x.ActiveBuffer

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -88,7 +88,9 @@ type internal ModeMap
         // the previous non-visual mode value.  Commands executing in Visual mode
         // which return a SwitchPrevious mode value expected to actually leave 
         // Visual Mode 
-        if not (VisualKind.IsAnyVisualOrSelect currentMode.ModeKind) && not (VisualKind.IsAnyVisualOrSelect _previousMode.ModeKind) then
+        if currentMode.ModeKind = ModeKind.Disabled then
+            _previousMode <- _modeMap.Item ModeKind.Normal
+        elif not (VisualKind.IsAnyVisualOrSelect currentMode.ModeKind) && not (VisualKind.IsAnyVisualOrSelect _previousMode.ModeKind) then
             _previousMode <- currentMode
         elif _previousMode.ModeKind = ModeKind.Uninitialized then
             _previousMode <- currentMode

--- a/Test/VimCoreTest/DisabledModeTest.cs
+++ b/Test/VimCoreTest/DisabledModeTest.cs
@@ -111,6 +111,39 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Re-enabling with an active selection and 'selectmode='
+            /// should enable visual mode and return to normal mode
+            /// </summary>
+            [Fact]
+            public void ReenableActiveSelectionNoSelectModeMouse()
+            {
+                _vimBuffer1.Process(GlobalSettings.DisableAllCommand);
+                Assert.Equal(ModeKind.Disabled, _vimBuffer1.ModeKind);
+                _vimBuffer1.TextView.Selection.Select(0, _vimBuffer1.TextView.GetEndPoint().Position);
+                _vimBuffer1.Process(GlobalSettings.DisableAllCommand);
+                Assert.Equal(ModeKind.VisualCharacter, _vimBuffer1.ModeKind);
+                _vimBuffer1.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer1.ModeKind);
+            }
+
+            /// <summary>
+            /// Re-enabling with an active selection and 'selectmode=mouse'
+            /// should enable select mode and return to normal mode
+            /// </summary>
+            [Fact]
+            public void ReenableActiveSelectionSelectModeMouse()
+            {
+                _vimBuffer1.GlobalSettings.SelectMode = "mouse";
+                _vimBuffer1.Process(GlobalSettings.DisableAllCommand);
+                Assert.Equal(ModeKind.Disabled, _vimBuffer1.ModeKind);
+                _vimBuffer1.TextView.Selection.Select(0, _vimBuffer1.TextView.GetEndPoint().Position);
+                _vimBuffer1.Process(GlobalSettings.DisableAllCommand);
+                Assert.Equal(ModeKind.SelectCharacter, _vimBuffer1.ModeKind);
+                _vimBuffer1.ProcessNotation("<Esc>");
+                Assert.Equal(ModeKind.Normal, _vimBuffer1.ModeKind);
+            }
+
+            /// <summary>
             /// When we re-enable Vim they buffers which are already out of Disabled Mode should remain in 
             /// whatever mode they are in 
             /// </summary>


### PR DESCRIPTION
- Choose appropriate mode upon being re-enabled
- Record previous mode as normal instead of disabled when switching
- Add unit tests for disabled mode and active selection
