### PR TITLE
Fix regression in dragging to start visual mode

### DIFF
--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -27,6 +27,9 @@ type KeyInput
     /// Is this a function key
     member x.IsFunctionKey = VimKeyUtil.IsFunctionKey _key
 
+    /// Is this a mouse key
+    member x.IsMouseKey = VimKeyUtil.IsMouseKey _key
+
     /// In general Vim keys compare ordinally.  The one exception is when the control
     /// modifier is applied to a letter key.  In that case the keys compare in a case 
     /// insensitive fashion.  

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -31,6 +31,9 @@ type KeyInput =
     /// Is this a function key
     member IsFunctionKey : bool
 
+    /// Is this a mouse key
+    member IsMouseKey : bool
+
     /// The empty KeyInput.  Used in places where a KeyInput is required but no 
     /// good mapping exists
     static member DefaultValue : KeyInput

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -217,7 +217,10 @@ type internal VisualMode
                 | BindResult.Error ->
                     _selectionTracker.UpdateSelection()
                     _operations.Beep()
-                    ProcessResult.Handled ModeSwitch.NoSwitch
+                    if ki.IsMouseKey then
+                        ProcessResult.NotHandled
+                    else
+                        ProcessResult.Handled ModeSwitch.NoSwitch
                 | BindResult.Cancelled -> 
                     _selectionTracker.UpdateSelection()
                     ProcessResult.Handled ModeSwitch.NoSwitch

--- a/Src/VimCore/VimKey.fs
+++ b/Src/VimCore/VimKey.fs
@@ -125,6 +125,26 @@ module VimKeyUtil =
         | VimKey.F12 -> true
         | _ -> false
 
+    /// Is this a mouse key
+    let IsMouseKey key =
+        match key with
+        | VimKey.LeftMouse -> true
+        | VimKey.LeftRelease -> true
+        | VimKey.LeftDrag -> true
+        | VimKey.RightMouse -> true
+        | VimKey.RightRelease -> true
+        | VimKey.RightDrag -> true
+        | VimKey.MiddleMouse -> true
+        | VimKey.MiddleRelease -> true
+        | VimKey.MiddleDrag -> true
+        | VimKey.X1Mouse -> true
+        | VimKey.X1Release -> true
+        | VimKey.X1Drag -> true
+        | VimKey.X2Mouse -> true
+        | VimKey.X2Release -> true
+        | VimKey.X2Drag -> true
+        | _ -> false
+
 [<System.Flags>]
 type KeyModifiers = 
     | None = 0x0


### PR DESCRIPTION
- Add new IsMouseKey predicate
- Don't handle unmatched mouse keys in visual mode
