### PR TITLE
Add support for one-time-commands from select mode

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -2791,28 +2791,17 @@ type internal CommandUtil
     /// Switch to other visual mode: visual from select or vice versa
     member x.SwitchModeOtherVisual visualSpan =
         let currentModeKind = _vimBufferData.VimTextBuffer.ModeKind
-        let newModeKind =
-            match currentModeKind with
-            | ModeKind.VisualBlock -> ModeKind.SelectBlock
-            | ModeKind.VisualCharacter -> ModeKind.SelectCharacter
-            | ModeKind.VisualLine -> ModeKind.SelectLine
-            | ModeKind.SelectBlock -> ModeKind.VisualBlock
-            | ModeKind.SelectCharacter -> ModeKind.VisualCharacter
-            | ModeKind.SelectLine -> ModeKind.VisualLine
-            | _ -> currentModeKind
-        let anchorPoint =
-            _vimBufferData.VisualCaretStartPoint
-            |> OptionUtil.map2 (TrackingPointUtil.GetPoint x.CurrentSnapshot)
-        match anchorPoint with
+        match VisualKind.OfModeKind currentModeKind with
+        | Some visualKind ->
+            let newModeKind =
+                if VisualKind.IsAnySelect currentModeKind then
+                    visualKind.VisualModeKind
+                else
+                    visualKind.SelectModeKind
+            x.SwitchMode newModeKind ModeArgument.None
         | None ->
             _commonOperations.Beep()
             CommandResult.Completed ModeSwitch.NoSwitch
-        | Some anchorPoint ->
-            let caretPoint = x.CaretPoint
-            let visualSelection = VisualSelection.CreateForPoints visualSpan.VisualKind anchorPoint caretPoint _localSettings.TabStop
-            let visualSelection = visualSelection.AdjustForSelectionKind _globalSettings.SelectionKind
-            let modeArgument = ModeArgument.InitialVisualSelection (visualSelection, Some anchorPoint)
-            x.SwitchMode newModeKind modeArgument
 
     /// Switch from the current visual mode into the specified visual mode
     member x.SwitchModeVisual newVisualKind = 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1164,16 +1164,22 @@ type VisualKind =
 
     static member All = [ Character; Line; Block ] |> Seq.ofList
 
-    static member OfModeKind kind = 
-        match kind with 
-        | ModeKind.VisualBlock -> VisualKind.Block |> Some
-        | ModeKind.VisualLine -> VisualKind.Line |> Some
-        | ModeKind.VisualCharacter -> VisualKind.Character |> Some
+    static member OfModeKind kind =
+        match kind with
+        | ModeKind.VisualCharacter | ModeKind.SelectCharacter -> VisualKind.Character |> Some
+        | ModeKind.VisualLine | ModeKind.SelectLine -> VisualKind.Line |> Some
+        | ModeKind.VisualBlock | ModeKind.SelectBlock -> VisualKind.Block |> Some
         | _ -> None
 
-    static member IsAnyVisual kind = VisualKind.OfModeKind kind |> Option.isSome
+    static member IsAnyVisual kind =
+        match kind with
+        | ModeKind.VisualCharacter -> true
+        | ModeKind.VisualLine -> true
+        | ModeKind.VisualBlock -> true
+        | _ -> false
 
-    static member IsAnySelect kind = 
+
+    static member IsAnySelect kind =
         match kind with
         | ModeKind.SelectCharacter -> true
         | ModeKind.SelectLine -> true
@@ -2182,7 +2188,7 @@ type ModeSwitch =
 
     /// Switch to the given mode for a single command.  After the command is processed switch
     /// back to the original mode
-    | SwitchModeOneTimeCommand
+    | SwitchModeOneTimeCommand of ModeKind
 
 [<RequireQualifiedAccess>]
 [<NoComparison>]
@@ -3433,6 +3439,33 @@ type ProcessResult =
         | NotHandled -> 
             false
         | Error -> 
+            false
+
+    /// Is this any type of switch to a visual mode
+    member x.IsAnySwitchToVisual =
+        match x with
+        | ProcessResult.Handled modeSwitch ->
+            match modeSwitch with
+            | ModeSwitch.SwitchMode modeKind ->
+                VisualKind.IsAnyVisualOrSelect modeKind
+            | ModeSwitch.SwitchModeWithArgument(modeKind, _) ->
+                VisualKind.IsAnyVisualOrSelect modeKind
+            | ModeSwitch.SwitchModeOneTimeCommand modeKind ->
+                VisualKind.IsAnyVisualOrSelect modeKind
+            | _ ->
+                false
+        | _ ->
+            false
+
+    // Is this a switch to command mode?
+    member x.IsAnySwitchToCommand =
+        match x with
+        | ProcessResult.Handled modeSwitch ->
+            match modeSwitch with
+            | ModeSwitch.SwitchMode modeKind -> modeKind = ModeKind.Command
+            | ModeSwitch.SwitchModeWithArgument (modeKind, _) -> modeKind = ModeKind.Command
+            | _ -> false
+        | _ ->
             false
 
     /// Did this actually handle the KeyInput

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -515,7 +515,7 @@ type internal InsertMode
     /// Enter normal mode for a single command.
     member x.ProcessNormalModeOneCommand keyInput =
 
-        let switch = ModeSwitch.SwitchModeOneTimeCommand
+        let switch = ModeSwitch.SwitchModeOneTimeCommand ModeKind.Normal
         ProcessResult.Handled switch
 
     /// Process the CTRL-N key stroke which calls for the previous word completion

--- a/Src/VimCore/Modes_Visual_SelectMode.fs
+++ b/Src/VimCore/Modes_Visual_SelectMode.fs
@@ -185,6 +185,8 @@ type internal SelectMode
             elif keyInput.Key = VimKey.Delete || keyInput.Key = VimKey.Back then
                 x.ProcessInput "" false |> ignore
                 ProcessResult.Handled ModeSwitch.SwitchPreviousMode
+            elif keyInput = KeyInputUtil.CharWithControlToKeyInput 'o' then
+                x.ProcessVisualModeOneCommand keyInput
             else
                 match GetCaretMovement keyInput with
                 | Some caretMovement ->
@@ -205,11 +207,24 @@ type internal SelectMode
                             _selectionTracker.UpdateSelection()
                             ProcessResult.Handled ModeSwitch.NoSwitch
 
-        if processResult.IsAnySwitch then
+        /// Restore or clear the selection depending on the next mode
+        if processResult.IsAnySwitchToVisual then
+            _selectionTracker.UpdateSelection()
+        elif processResult.IsAnySwitch then
             _textView.Selection.Clear()
             _textView.Selection.Mode <- TextSelectionMode.Stream
 
         processResult
+
+    /// Enter visual mode for a single command.
+    member x.ProcessVisualModeOneCommand keyInput =
+        match VisualKind.OfModeKind _modeKind with
+        | Some visualKind ->
+            let modeKind = visualKind.VisualModeKind
+            let modeSwitch = ModeSwitch.SwitchModeOneTimeCommand modeKind
+            ProcessResult.Handled modeSwitch
+        | None ->
+            ProcessResult.Error
 
     member x.OnEnter modeArgument =
         x.EnsureCommandsBuilt()

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -229,22 +229,6 @@ type internal VisualMode
         // we are the active IMode.  It's very possible that we were switched out already 
         // as part of a complex command
         if result.IsAnySwitch && _selectionTracker.IsRunning then
-            // Is this a switch to command mode? 
-            let toCommandMode = 
-                match result with
-                | ProcessResult.NotHandled -> 
-                    false
-                | ProcessResult.Error ->
-                    false
-                | ProcessResult.HandledNeedMoreInput ->
-                    false
-                | ProcessResult.Handled switch ->
-                    match switch with 
-                    | ModeSwitch.NoSwitch -> false
-                    | ModeSwitch.SwitchMode modeKind -> modeKind = ModeKind.Command
-                    | ModeSwitch.SwitchModeWithArgument (modeKind, _) -> modeKind = ModeKind.Command
-                    | ModeSwitch.SwitchPreviousMode -> false
-                    | ModeSwitch.SwitchModeOneTimeCommand -> false
 
             // On teardown we will get calls to Stop when the view is closed.  It's invalid to access 
             // the selection at that point
@@ -253,7 +237,9 @@ type internal VisualMode
                 // Before resetting the selection save it
                 _vimTextBuffer.LastVisualSelection <- Some lastVisualSelection
 
-                if not toCommandMode then
+                if result.IsAnySwitchToVisual then
+                    _selectionTracker.UpdateSelection()
+                elif not result.IsAnySwitchToCommand then
                     _textView.Selection.Clear()
                     _textView.Selection.Mode <- TextSelectionMode.Stream
 

--- a/Test/VimCoreTest/SelectModeIntegrationTest.cs
+++ b/Test/VimCoreTest/SelectModeIntegrationTest.cs
@@ -884,6 +884,28 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("<C-q>");
                 Assert.Equal(ModeKind.SelectBlock, _vimBuffer.ModeKind);
             }
+
+            /// <summary>
+            /// Make sure 'C-o' works from select mode
+            /// </summary>
+            [Fact]
+            public void SelectOneTimeCommand()
+            {
+                Create("cat dog eel");
+                _globalSettings.Selection = "exclusive";
+                _vimBuffer.ProcessNotation("wgh");
+                Assert.Equal(ModeKind.SelectCharacter, _vimBuffer.ModeKind);
+                Assert.Equal("d", _textView.GetSelectionSpan().GetText());
+                _vimBuffer.ProcessNotation("<C-o>");
+                Assert.Equal(ModeKind.VisualCharacter, _vimBuffer.ModeKind);
+                Assert.Equal("d", _textView.GetSelectionSpan().GetText());
+                _vimBuffer.ProcessNotation("w");
+                Assert.Equal("dog ", _textView.GetSelectionSpan().GetText());
+                Assert.Equal(ModeKind.SelectCharacter, _vimBuffer.ModeKind);
+                _vimBuffer.ProcessNotation("bear ");
+                Assert.Equal(ModeKind.Insert, _vimBuffer.ModeKind);
+                Assert.Equal("cat bear eel", _textBuffer.GetLine(0).GetText());
+            }
         }
     }
 }

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -493,7 +493,7 @@ namespace Vim.UnitTest
             public void SwitchModeOneTimeCommand_SetProperty()
             {
                 var mode = CreateAndAddInsertMode(MockBehavior.Loose);
-                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.NewHandled(ModeSwitch.SwitchModeOneTimeCommand));
+                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.NewHandled(ModeSwitch.NewSwitchModeOneTimeCommand(ModeKind.Normal)));
                 _vimBuffer.SwitchMode(ModeKind.Insert, ModeArgument.None);
                 _vimBuffer.Process('c');
                 Assert.True(_vimBuffer.InOneTimeCommand.IsSome(ModeKind.Insert));


### PR DESCRIPTION
- Add 'Ctrl+O' in select mode to run one-time command in visual mode
- Add ModeKind argument to SwitchModeOneTimeCommand
- Rewrite SwitchModeOtherVisual to use implicit selection instead of mode argument
- Refactor IsAnySwitchToCommand into a utility
- Make ModeKind/VisualKind utilities symmetric for visual and select cases
- Allow visual commands to stop after one command if going back to select mode
- Add select mode integration test for one-time command
