### PR TITLE
Fix parser hang on syntax error

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1177,10 +1177,13 @@ type Parser
                 _tokenizer.MoveNextToken()
                 Some LineSpecifier.CurrentLine
             elif _tokenizer.CurrentChar = '\'' then
+                let mark = _tokenizer.Mark
                 _tokenizer.MoveNextToken()
 
                 match Mark.OfChar _tokenizer.CurrentChar with
-                | None -> None
+                | None -> 
+                    _tokenizer.MoveToMark mark
+                    None
                 | Some mark -> 
                     _tokenizer.MoveNextChar()
                     LineSpecifier.MarkLine mark |> Some
@@ -2070,7 +2073,7 @@ type Parser
             c |> StringUtil.ofChar |> x.TryExpand |> doParse
         | TokenKind.EndOfLine ->
             match lineRange with
-            | LineRangeSpecifier.None -> LineCommand.Nop
+            | LineRangeSpecifier.None -> handleParseResult LineCommand.Nop
             | _ -> x.ParseJumpToLine lineRange |> handleParseResult
         | _ -> 
             x.ParseJumpToLine lineRange |> handleParseResult
@@ -2079,7 +2082,6 @@ type Parser
     /// it won't ever return LineCommand.FuntionStart but instead will return LineCommand.Function
     /// instead
     member x.ParseSingleCommand() =
-
         match x.ParseSingleLine() with 
         | LineCommand.FunctionStart functionDefinition -> x.ParseFunction functionDefinition 
         | LineCommand.IfStart expr -> x.ParseIf expr

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -421,6 +421,33 @@ namespace Vim.UnitTest
                 Assert.True(_globalSettings.IncrementalSearch);
                 Assert.Equal(4, _localSettings.TabStop);
             }
+
+            /// <summary>
+            /// Make sure we handle blank lines in the script just fine
+            /// </summary>
+            [Fact]
+            public void HasBlankLine()
+            {
+                Create("");
+                RunScript(
+                    "set incsearch",
+                    "",
+                    "set ts=4");
+                Assert.True(_globalSettings.IncrementalSearch);
+                Assert.Equal(4, _localSettings.TabStop);
+            }
+
+            [Fact]
+            public void SyntaxError()
+            {
+                Create("");
+                RunScript(
+                    "set incsearch",
+                    "'",
+                    "set ts=4");
+                Assert.True(_globalSettings.IncrementalSearch);
+                Assert.Equal(4, _localSettings.TabStop);
+            }
         }
 
         public sealed class SetTest : InterpreterTest


### PR DESCRIPTION
**N.B.** This is a staging commit that never got integrated into master.  I just cherry-picked it from staging.

In the case where a line of a script contained a single quote character
and nothing else the parser would enter an infinite loop due to 2 bugs.

The first was that ParseLineRangeSpecifier didn't properly unwind when
it found an incomplete line range.  That function should parse a line
range or not modify the token stream.  In this particular case it was
consuming the single quote and failing.  It now properly unwinds

The second bug is that in the parser didn't always move to the next
line.  This could only be exposed with the first bug but it was fixed
anyways to always move to a new line
