### PR TITLE
When running any backspacing command fill in virtual spaces

### DIFF
--- a/Test/VimCoreTest/InsertModeIntegrationTest.cs
+++ b/Test/VimCoreTest/InsertModeIntegrationTest.cs
@@ -736,7 +736,6 @@ namespace Vim.UnitTest
                 _vimBuffer.ProcessNotation("<Enter><BS>");
                 Assert.Equal("  hello", _textView.GetLine(0).GetText());
                 Assert.Equal(" ", _textView.GetLine(1).GetText());
-                Assert.Equal(2, _textView.GetCaretVirtualPoint().VirtualSpaces);
             }
 
             /// <summary>


### PR DESCRIPTION
When running any backspacing command fill in virtual spaces

Closes #1323

In my opinion, this is a pretty serious defect and warrants a point release.
