### PR TITLE
1358 - fix textobject select/delete (vab/yab/yib,etc.) when caret on end char

### DIFF
--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -791,8 +791,11 @@ type internal MotionUtil
             inner
 
         let snapshot = SnapshotPointUtil.GetSnapshot contextPoint
+        let endPoint = if isChar endChar contextPoint then contextPoint 
+                       else SnapshotPointUtil.AddOneOrCurrent contextPoint
+
         let startPoint = 
-            SnapshotSpan(SnapshotPoint(snapshot, 0), SnapshotPointUtil.AddOneOrCurrent contextPoint)
+            SnapshotSpan(SnapshotPoint(snapshot, 0), endPoint)
             |> SnapshotSpanUtil.GetPoints Path.Backward
             |> SeqUtil.tryFind 1 (findMatched endChar startChar)
 

--- a/Test/VimCoreTest/MotionUtilTest.cs
+++ b/Test/VimCoreTest/MotionUtilTest.cs
@@ -2561,6 +2561,26 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
+            /// Make sure that we can process the nested block when the caret is at the end
+            /// </summary>
+            [Fact]
+            public void GetBlock_Nested_FromLastChar()
+            {
+                Create("cat (fo(a)od) dog");
+                var span = _motionUtil.GetBlock(BlockKind.Paren, _textBuffer.GetPoint(12)).Value;
+                Assert.Equal(_textBuffer.GetSpan(4, 9), span);
+            }
+            /// <summary>
+            /// Make sure that we can process the nested block when the caret is at the start
+            /// </summary>
+            [Fact]
+            public void GetBlock_Nested_FromFirstChar()
+            {
+                Create("cat (fo(a)od) dog");
+                var span = _motionUtil.GetBlock(BlockKind.Paren, _textBuffer.GetPoint(4)).Value;
+                Assert.Equal(_textBuffer.GetSpan(4, 9), span);
+            }
+            /// <summary>
             /// Bad match because of no start char
             /// </summary>
             [Fact]


### PR DESCRIPTION
An attempt to fix issue #1358, where commands like vab failed on text "a(b)c" when the caret was already on the closing paren.

This is my first time in the code and I don't know F# very well, so this fix might be way off the mark.   
