### PR TITLE
Expand variables with lowercase letters

### DIFF
--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -891,8 +891,14 @@ module internal SystemUtil =
             else
                 token
 
+        // According to Shell and Utilities volume of IEEE Std 1003.1-2001
+        // standard environment variable names should consist solely of
+        // uppercase letters, digits, and the '_'. However variables with
+        // lowercasesee lowercase letters are also popular, thus the regex
+        // below supports them as well.
+        // http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
         let text =
-            Regex.Matches(text, "(\$[A-Z]+)|([^$]+)")
+            Regex.Matches(text, "(\$[\w_][\w\d_]*)|([^$]+)")
             |> Seq.cast
             |> Seq.map processMatch
             |> String.concat ""

--- a/Test/VimCoreTest/SystemUtilTest.cs
+++ b/Test/VimCoreTest/SystemUtilTest.cs
@@ -61,6 +61,20 @@ namespace Vim.UnitTest
             Assert.Equal(@"c:\foo\bar", SystemUtil.ResolvePath(@"~\bar"));
         }
 
+        [Fact]
+        public void ResolvePath_Lowercase()
+        {
+            Environment.SetEnvironmentVariable("lowercase", @"c:\foo");
+            Assert.Equal(@"c:\foo\bar", SystemUtil.ResolvePath(@"$lowercase\bar"));
+        }
+
+        [Fact]
+        public void ResolvePath_Underscore()
+        {
+            Environment.SetEnvironmentVariable("var_with_underscore", @"c:\foo");
+            Assert.Equal(@"c:\foo\bar", SystemUtil.ResolvePath(@"$var_with_underscore\bar"));
+        }
+
         /// <summary>
         /// Test the cases we expect to work for CombinePath
         /// </summary>


### PR DESCRIPTION
SystemUtil.ResolvePath should expand variables with lowercase letters and underscore.
