### PR TITLE
:vs not :vsp is the shortest abbrev for :vsplit

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -182,7 +182,7 @@ type Parser
         ("vglobal", "v")
         ("version", "ve")
         ("vscmd", "vsc")
-        ("vsplit", "vsp")
+        ("vsplit", "vs")
         ("write","w")
         ("wq", "")
         ("wall", "wa")


### PR DESCRIPTION
This embarrassingly small pull request (seriously?! What a mighty programmer, to delete one character!) fixes #1424. No automated tests updated because this feature is not currently under automated test.
