### PR TITLE
Allow many types of expressions on RHS of :let

### DIFF
--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -540,7 +540,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     | JumpToLastLine
 
     // Let command.  The first item is the name and the second is the value
-    | Let of VariableName * VariableValue
+    | Let of VariableName * Expression
 
     /// Make command.  The options are as follows
     ///   - The ! option

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -764,10 +764,10 @@ type VimInterpreter
         _commonOperations.MoveCaretToPoint point (ViewFlags.Standard &&& (~~~ViewFlags.TextExpanded))
 
     /// Run the let command
-    member x.RunLet (name : VariableName) value =
+    member x.RunLet (name : VariableName) expr =
         // TODO: At this point we are treating all variables as if they were global.  Need to 
         // take into account the NameScope at this level too
-        _variableMap.[name.Name] <- value
+        _variableMap.[name.Name] <- x.RunExpression expr
 
     /// Run the host make command 
     member x.RunMake hasBang arguments = 

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1741,11 +1741,8 @@ type Parser
             | ParseResult.Succeeded name ->
                 if _tokenizer.CurrentChar = '=' then
                     _tokenizer.MoveNextToken()
-                    match x.ParseSingleExpression() with
-                    | ParseResult.Succeeded expr ->
-                        match expr with
-                        | Expression.ConstantValue value -> LineCommand.Let (name, value)
-                        | _ -> LineCommand.ParseError "Not implemented: let only works with constant values"
+                    match x.ParseExpressionCore() with
+                    | ParseResult.Succeeded expr -> LineCommand.Let (name, expr)
                     | ParseResult.Failed msg -> LineCommand.ParseError msg
                 else
                     parseDisplayLet name

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -882,6 +882,11 @@ namespace Vim.UnitTest
                 AssertValue(name, VariableValue.NewNumber(value));
             }
 
+            private void AssertValue(string name, string value)
+            {
+                AssertValue(name, VariableValue.NewString(value));
+            }
+
             private void AssertValue(string name, VariableValue value)
             {
                 Assert.Equal(value, _variableMap[name]);
@@ -908,7 +913,7 @@ namespace Vim.UnitTest
             {
                 Create("");
                 ParseAndRun(@"let x= 'oo'");
-                AssertValue("x", VariableValue.NewString("oo"));
+                AssertValue("x", "oo");
             }
 
             [Fact]
@@ -925,6 +930,23 @@ namespace Vim.UnitTest
                 Create("");
                 ParseAndRun(@"let x = 42");
                 AssertValue("x", 42);
+            }
+
+            [Fact]
+            public void RHSCanBeArbitraryExpression()
+            {
+                Create("");
+                UnnamedRegister.UpdateValue("Hello, world!");
+                ParseAndRun("let x=@\"");
+                AssertValue("x", "Hello, world!");
+            }
+
+            [Fact]
+            public void RHSCanBeBinaryExpression()
+            {
+                Create("");
+                ParseAndRun("let x=1+2");
+                AssertValue("x", 3);
             }
         }
 


### PR DESCRIPTION
Support statements such as `:let x=1+2`, `let x=@a`, `let x=&tabstop`,
etc, by making the right-hand-side of `:let` look for expressions
instead of just literals.

This rounds out what I did with `:echo`.
