### PR TITLE
Implemented the concat operator for integers and strings

### DIFF
--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -96,11 +96,24 @@ type ExpressionInterpreter
                 | Some left, Some right -> left + right |> VariableValue.Number
                 | _ -> VariableValue.Error
 
+        let runConcat (lvalue : string) (rightValue : VariableValue) =
+            match rightValue with
+            | VariableValue.String rvalue -> VariableValue.String (lvalue + rvalue)
+            | VariableValue.Number rvalue -> VariableValue.String (lvalue + (string rvalue))
+            | _ -> VariableValue.Error
+
+        let runConcat (leftValue : VariableValue) (rightValue : VariableValue) =
+            match leftValue with
+            | VariableValue.String lvalue -> runConcat lvalue rightValue
+            | VariableValue.Number lvalue -> runConcat (string lvalue) rightValue
+            | _ -> VariableValue.Error
+            
+
         let leftValue = x.RunExpression leftExpr
         let rightValue = x.RunExpression rightExpr
         match binaryKind with
         | BinaryKind.Add -> runAdd leftValue rightValue
-        | BinaryKind.Concatenate -> notSupported()
+        | BinaryKind.Concatenate -> runConcat leftValue rightValue
         | BinaryKind.Divide -> notSupported()
         | BinaryKind.Modulo -> notSupported()
         | BinaryKind.Multiply -> notSupported()

--- a/Test/VimCoreTest/ExpressionInterpreterTest.cs
+++ b/Test/VimCoreTest/ExpressionInterpreterTest.cs
@@ -22,6 +22,12 @@ namespace Vim.UnitTest
             return _interpreter.RunExpression(parseResult.AsSucceeded().Item);
         }
 
+        private void Run(string expr, string expected)
+        {
+            var value = Run(expr);
+            Assert.Equal(expected, value.AsString().Item);
+        }
+
         private void Run(string expr, int number)
         {
             var value = Run(expr);
@@ -35,6 +41,18 @@ namespace Vim.UnitTest
         public void Add_SimpleNumber()
         {
             Run("1 + 2", 3);
+        }
+
+        [Fact]
+        public void Concat_two_strings()
+        {
+            Run("'vs' . 'vim'", "vsvim");
+        }
+
+        [Fact]
+        public void Concat_two_integers()
+        {
+            Run("2 . 3", "23");
         }
     }
 }


### PR DESCRIPTION
This is one of the more important of the binary operators. Within Vim, it seems to only support integers and strings, not even floats. Attempted to mimic that behavior here.
