### PR TITLE
Implement :execute command

### DIFF
--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -474,6 +474,9 @@ and [<RequireQualifiedAccess>] LineCommand =
     // The :echo command
     | Echo of Expression
 
+    // The :execute command
+    | Execute of Expression
+
     /// The :edit command.  The values range as follows
     ///  - ! option present
     ///  - The provided ++opt

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -134,6 +134,7 @@ type Parser
         ("echo", "ec")
         ("edit", "e")
         ("else", "el")
+        ("execute", "exe")
         ("elseif", "elsei")
         ("endfunction", "endf")
         ("endif", "en")
@@ -1717,6 +1718,17 @@ type Parser
             | ParseResult.Failed msg -> LineCommand.ParseError msg
             | ParseResult.Succeeded expr -> LineCommand.Echo expr
 
+    /// Parse out the :execute command
+    member x.ParseExecute () = 
+        use flags = _tokenizer.SetTokenizerFlagsScoped TokenizerFlags.AllowDoubleQuote
+        x.SkipBlanks()
+        if _tokenizer.IsAtEndOfLine then
+            LineCommand.Nop
+        else
+            match x.ParseExpressionCore() with
+            | ParseResult.Failed msg -> LineCommand.ParseError msg
+            | ParseResult.Succeeded expr -> LineCommand.Execute expr
+
     /// Parse out the :let command
     member x.ParseLet () = 
         use flags = _tokenizer.SetTokenizerFlagsScoped TokenizerFlags.SkipBlanks
@@ -2029,6 +2041,7 @@ type Parser
                 | "echo" -> noRange x.ParseEcho
                 | "edit" -> noRange x.ParseEdit
                 | "else" -> noRange x.ParseElse
+                | "execute" -> noRange x.ParseExecute
                 | "elseif" -> noRange x.ParseElseIf
                 | "endfunction" -> noRange x.ParseFunctionEnd
                 | "endif" -> noRange x.ParseIfEnd

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -876,6 +876,24 @@ namespace Vim.UnitTest
             }
         }
 
+        public sealed class ExecuteTest : InterpreterTest
+        {
+            [Fact]
+            public void ExecuteWithNoArgumentsDoesNothing()
+            {
+                Create("");
+                ParseAndRun("execute");
+                Assert.Equal(null, _statusUtil.LastStatus);
+            }
+            [Fact]
+            public void ExecuteString()
+            {
+                Create("");
+                ParseAndRun("execute \"echo 'asdf'\"");
+                Assert.Equal("asdf", _statusUtil.LastStatus);
+            }
+        }
+
         public sealed class LetTest : InterpreterTest
         {
             Dictionary<string, VariableValue> _variableMap;


### PR DESCRIPTION
`:execute` is important piece of VimScript and its usefulness can start to be realized now because of the increased expression support that I've been working on. Also it was a fairly low-hanging fruit given that it is just pumping stuff back through the same VimScript engine we are already building.

I have in my mind the distant goal of being able to support some simple plugins and in my experience `:execute` is very common. It also works in conjunction with the `.` operator I just implemented. 
