### PR TITLE
Command margin colors exposed in settings

### DIFF
--- a/Test/VimCoreTest/FileSystemTest.cs
+++ b/Test/VimCoreTest/FileSystemTest.cs
@@ -72,7 +72,7 @@ namespace Vim.UnitTest
             [Fact]
             public void UmlautNoBom()
             {
-                var line = "let map = ?";
+                var line = "let map = ö";
                 var encoding = Encoding.GetEncoding("Latin1");
                 var bytes = encoding.GetBytes(line);
                 File.WriteAllBytes(_tempFilePath, bytes);
@@ -83,7 +83,7 @@ namespace Vim.UnitTest
             [Fact]
             public void UmlautWithBom()
             {
-                var line = "let map = ?";
+                var line = "let map = ö";
                 var encoding = Encoding.GetEncoding("Latin1");
                 File.WriteAllLines(_tempFilePath, new[] { line }, encoding);
                 var lines = _fileSystem.ReadAllLines(_tempFilePath).Value;


### PR DESCRIPTION
This changeset exposes Command Margin color settings in the Default option page of VsVim.

The default black-on-white scheme is blazing on dark themes.
I thought there's nowhere to set the color before I dig into the code, actually.
So I guess it's better to make it more obvious.

About the Filesystem change: sorry I guess it's BOM related.. doesn't compile here so I changed that character. Please ignore that.
