### PR TITLE
Parse variable names with underscores in them (e.g. for plugins)

### DIFF
--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -455,6 +455,7 @@ module internal CharUtil =
     let IsNotBlank x = not (IsBlank x)
     let IsAlpha x = (x >= 'a' && x <= 'z') || (x >= 'A' && x <= 'Z')
     let IsLetter x = System.Char.IsLetter(x)
+    let IsWordChar x = IsLetter x || x = '_'
     let IsUpper x = System.Char.IsUpper(x)
     let IsUpperLetter x = IsUpper x && IsLetter x
     let IsLower x = System.Char.IsLower(x)

--- a/Src/VimCore/Interpreter_Tokenizer.fs
+++ b/Src/VimCore/Interpreter_Tokenizer.fs
@@ -137,7 +137,7 @@ type internal TokenStream() =
         let isCurrentLetter () = 
             match x.CurrentChar with
             | None -> false
-            | Some c -> CharUtil.IsLetter c
+            | Some c -> CharUtil.IsWordChar c
 
         while isCurrentLetter() do
             x.IncrementIndex()

--- a/Test/VimCoreTest/TokenizerTest.cs
+++ b/Test/VimCoreTest/TokenizerTest.cs
@@ -1,5 +1,4 @@
-﻿using Vim.Extensions;
-using Vim.Interpreter;
+﻿using Vim.Interpreter;
 using Xunit;
 
 namespace Vim.UnitTest
@@ -130,6 +129,20 @@ namespace Vim.UnitTest
                 }
                 Assert.Equal(before, _tokenizer.TokenizerFlags);
             }
+        }
+
+        public sealed class WordTest : TokenizerTest
+        {
+            [Fact]
+            public void WordsCanContainUnderscores()
+            {
+                Create("loaded_surround");
+                AssertWord("loaded_surround");
+            }
+
+            // TODO I don't care about these right now, but it's worth pointing out that:
+            // Words in VimL can also begin with underscores
+            // Words in VimL can contain (but not begin with) digits
         }
 
         public sealed class MiscTest : TokenizerTest


### PR DESCRIPTION
This is important for plugins, which declare variables with names like `loaded_surround`. I have not bothered to make full VimL compliance; e.g. while Vim also supports variable names like `plan9` and `_lodash`, I have not bothered at this time to hammer that out (though that shouldn't be hard; it just didn't strike me as important right now).
