### PR TITLE
Fixed parsing of scoped variable names

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1579,6 +1579,7 @@ type Parser
         | TokenKind.Word word ->
             _tokenizer.MoveNextToken()
             if _tokenizer.CurrentChar = ':' then
+                _tokenizer.MoveNextToken()
                 match _tokenizer.CurrentTokenKind, parseNameScope word with
                 | TokenKind.Word name, Some nameScope -> 
                     _tokenizer.MoveNextToken()

--- a/Test/VimCoreTest/ParserTest.cs
+++ b/Test/VimCoreTest/ParserTest.cs
@@ -182,6 +182,13 @@ namespace Vim.UnitTest
                 var list = Parse("let x y");
                 Assert.Equal(new[] { "x", "y" }, list.Select(x => x.Name));
             }
+
+            [Fact]
+            public void ScopedVariable()
+            {
+                var list = Parse("let g:x");
+                Assert.Equal(new[] { "x" }, list.Select(x => x.Name));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed a bug in the parsing of scoped variable names. This does not yet implement the scoping itself; it just avoids a parse error. This is another component of my effort to get a trivial-case plugin working in VsVim.
