### PR TITLE
Fix the link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/jaredpar/VsVim/blob/master/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/VsVim/VsVim/blob/master/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 # Before you file a bug ...
 
@@ -17,5 +17,5 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 This repository actively manages issues to attempt to keep the set of open issues small enough to be easily managed, searchable and have clear timeline expectations. Here are the policies around issues:
 
 - Issues tagged as "Need more data" need more information from the opener to be acted on. If the information isn't provided within 7 days the issue will be closed. Will reopen if the data is provided at a later date.
-- Issues in the [Unscheduled Milestone](https://github.com/jaredpar/VsVim/milestone/11) are valid problems but one the maintainer doesn't expect to fix themselves. 
+- Issues in the [Unscheduled Milestone](https://github.com/VsVim/VsVim/milestone/11) are valid problems but one the maintainer doesn't expect to fix themselves. 
 

--- a/Documentation/CSharp scripting.md
+++ b/Documentation/CSharp scripting.md
@@ -74,7 +74,7 @@ If "Hello, World!" Is written in the first line of the editor, it is successful.
 With the Visual Studio SDK, you can create a something of extensions.  
 If you want to use the Visual Studio SDK, the following sentences will be helpful.  
 
-- [Resources for writing Visual Studio Extensions](https://github.com/jaredpar/VsVim/wiki/Resources-for-writing-Visual-Studio-Extensions)
+- [Resources for writing Visual Studio Extensions](https://github.com/VsVim/VsVim/wiki/Resources-for-writing-Visual-Studio-Extensions)
 
 ## Let's operate VsVim
 

--- a/Documentation/release-notes.md
+++ b/Documentation/release-notes.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ### Version 2.6.0
-[Issues closed in milestone 2.6.0](https://github.com/jaredpar/VsVim/milestone/45?closed=1)
+[Issues closed in milestone 2.6.0](https://github.com/VsVim/VsVim/milestone/45?closed=1)
 Primary Issues Addressed
 * Visual Studio 2019 support
 * Mark display in the editor margin
@@ -10,7 +10,7 @@ Primary Issues Addressed
 
 
 ### Version 2.5.0
-[Issues closed in milestone 2.5.0](https://github.com/jaredpar/VsVim/milestone/47?closed=1)
+[Issues closed in milestone 2.5.0](https://github.com/VsVim/VsVim/milestone/47?closed=1)
 
 Primary Issues Addressed
 * Support for the `.` register 
@@ -19,21 +19,21 @@ Primary Issues Addressed
 * Lots of infrastructure issues 
 
 ### Version 2.4.1
-[Issues closed in milestone 2.4.1](https://github.com/jaredpar/VsVim/milestone/47?closed=1)
+[Issues closed in milestone 2.4.1](https://github.com/VsVim/VsVim/milestone/47?closed=1)
 
 Primary Issues Addressed
 * `Escape` not leaving Visual Mode
 * License file changed to txt from rtf
 
 ### Version 2.4.0
-[Issues closed in milestone 2.4.0](https://github.com/jaredpar/VsVim/milestone/46?closed=1)
+[Issues closed in milestone 2.4.0](https://github.com/VsVim/VsVim/milestone/46?closed=1)
 
 Primary Issues Addressed
 * `gt` and `gT` support in VS 2017
 * Exception opening files in VS 2017
 
 ### Version 2.2.0
-[Issues closed in milestone 2.2.0](https://github.com/jaredpar/VsVim/milestone/44?closed=1)
+[Issues closed in milestone 2.2.0](https://github.com/VsVim/VsVim/milestone/44?closed=1)
 
 Primary Issues Addressed
 * Basic telemetry support
@@ -41,7 +41,7 @@ Primary Issues Addressed
 * Key mappings and completion in insert mode
 
 ### Version 2.1.0
-[Issues closed in milestone 2.1.0](https://github.com/jaredpar/VsVim/issues?q=milestone%3A2.1.0+is%3Aclosed)
+[Issues closed in milestone 2.1.0](https://github.com/VsVim/VsVim/issues?q=milestone%3A2.1.0+is%3Aclosed)
 
 Primary Issues Addressed
 * Clean macro recording
@@ -50,14 +50,14 @@ Patched Issues in 2.1.1
 * Many selection issues involving end of line
 
 ### Version 2.0.0
-[Issues closed in milestone 2.0.0](https://github.com/jaredpar/VsVim/issues?q=milestone%3A2.0.0)
+[Issues closed in milestone 2.0.0](https://github.com/VsVim/VsVim/issues?q=milestone%3A2.0.0)
 
 Primary Issues Addressed
 * Many fixes to the block motion
 * VS 2015 support 
 
 ### Version 1.8.0
-[Issues closed in milestone 1.8.0](https://github.com/jaredpar/VsVim/issues?q=milestone%3A1.8.0+is%3Aclosed)
+[Issues closed in milestone 1.8.0](https://github.com/VsVim/VsVim/issues?q=milestone%3A1.8.0+is%3Aclosed)
 
 Primary Issues Addressed
 * Rewrote regex replace code to support many more Vim features
@@ -65,7 +65,7 @@ Primary Issues Addressed
 * Undo bug fixes
 
 ### Version 1.7.1
-[Issues closed in milestone 1.7.1](https://github.com/jaredpar/VsVim/issues?q=milestone%3A1.7.1+is%3Aclosed)
+[Issues closed in milestone 1.7.1](https://github.com/VsVim/VsVim/issues?q=milestone%3A1.7.1+is%3Aclosed)
 
 Primary Issues Addressed
 * Better comment support in vimrc
@@ -77,7 +77,7 @@ Patched Issues in 1.7.1.1
 * Double click selection issue
 
 ### Version 1.7.0
-[Issues closed in milestone 1.7.0](https://github.com/jaredpar/VsVim/issues?milestone=40&page=1&state=closed)
+[Issues closed in milestone 1.7.0](https://github.com/VsVim/VsVim/issues?milestone=40&page=1&state=closed)
 
 Primary Issues Addressed
 * VsVim now has a proper options page (Tools -> Options) 
@@ -87,7 +87,7 @@ Primary Issues Addressed
 * Word wrap glyph support 
 
 ### Version 1.6.0
-[Issues closed in milestone 1.6.0](https://github.com/jaredpar/VsVim/issues?milestone=39&page=1&state=closed)
+[Issues closed in milestone 1.6.0](https://github.com/VsVim/VsVim/issues?milestone=39&page=1&state=closed)
 
 Primary Issues Addressed
 * Added support for `backspace` and `whichwrap`
@@ -108,7 +108,7 @@ Patched Issues in 1.6.0.3
 * Support for Dev14 
 
 ### Version 1.5.0
-[Issues closed in milestone 1.5.0](https://github.com/jaredpar/VsVim/issues?milestone=38&page=1&state=closed)
+[Issues closed in milestone 1.5.0](https://github.com/VsVim/VsVim/issues?milestone=38&page=1&state=closed)
 
 Primary Issues Addressed
 * Search offsets 
@@ -118,7 +118,7 @@ Primary Issues Addressed
 * Support for Peek Definition Window
 
 ### Version 1.4.2
-[Issues closed in milestone 1.4.2](https://github.com/jaredpar/VsVim/issues?milestone=36&page=1&state=closed)
+[Issues closed in milestone 1.4.2](https://github.com/VsVim/VsVim/issues?milestone=36&page=1&state=closed)
 
 Primary Issues Addressed
 * Support for scrolloff setting
@@ -127,7 +127,7 @@ Primary Issues Addressed
 * :wa not saving properly in html files
 
 ### Version 1.4.1
-[Issues closed in milestone 1.4.1](https://github.com/jaredpar/VsVim/issues?milestone=35&page=1&state=closed)
+[Issues closed in milestone 1.4.1](https://github.com/VsVim/VsVim/issues?milestone=35&page=1&state=closed)
 
 Primary Issues Addressed
 * Block selection and tab / wide character issues
@@ -138,7 +138,7 @@ Primary Issues Addressed
 * Perf issues around block caret drawing
 
 ### Version 1.4.0
-[Issues closed in milestone 1.4.0](https://github.com/jaredpar/VsVim/issues?milestone=33&page=1&state=closed)
+[Issues closed in milestone 1.4.0](https://github.com/VsVim/VsVim/issues?milestone=33&page=1&state=closed)
 
 Primary Issues Addressed
 * Basic autocmd support ([[Details|AutoCmd support]])
@@ -147,7 +147,7 @@ Primary Issues Addressed
 * Better support for `)` motions
 
 ### Version 1.3.3
-[Issues closed in milestone 1.3.3](https://github.com/jaredpar/VsVim/issues?milestone=32&page=1&state=closed)
+[Issues closed in milestone 1.3.3](https://github.com/VsVim/VsVim/issues?milestone=32&page=1&state=closed)
 
 Primary Issues Addressed
 * vimrc entries not being properly handled
@@ -168,7 +168,7 @@ Patched Issues (1.3.3.3)
 * Fixed live template support in Resharper
 
 ### Version 1.3.2
-[Issues closed in milestone 1.3.2](https://github.com/jaredpar/VsVim/issues?milestone=29&page=1&state=closed)
+[Issues closed in milestone 1.3.2](https://github.com/VsVim/VsVim/issues?milestone=29&page=1&state=closed)
 
 Primary Issues Addressed
 * Navigation issues with C style pragma directives
@@ -178,7 +178,7 @@ Primary Issues Addressed
 * Several bugs around handling of `shiftwidth` and `tabstop`
 
 ### Version 1.3.1
-[Issues closed in milestone 1.3.1](https://github.com/jaredpar/VsVim/issues?milestone=27&page=1&state=closed)
+[Issues closed in milestone 1.3.1](https://github.com/VsVim/VsVim/issues?milestone=27&page=1&state=closed)
 
 Primary Issues Addressed
 * Non-English keyboard handling
@@ -197,7 +197,7 @@ Patched Issues (1.3.1.3)
 * gt, gT, tabn weren't working on 2010
 
 ### Version 1.3.0
-[Issues closed in milestone 1.3](https://github.com/jaredpar/VsVim/issues?milestone=23&state=closed)
+[Issues closed in milestone 1.3](https://github.com/VsVim/VsVim/issues?milestone=23&state=closed)
 
 Primary Issues Addressed
 * Key Handling
@@ -217,7 +217,7 @@ Patched Issues (1.3.0.2)
 * Certain key mappings not working in insert mode
 
 ### Version 1.2.2
-[Issues closed in milestone 1.2.2](https://github.com/jaredpar/VsVim/issues?milestone=25&state=closed)
+[Issues closed in milestone 1.2.2](https://github.com/VsVim/VsVim/issues?milestone=25&state=closed)
 
 Primary Issues Addressed
 
@@ -226,7 +226,7 @@ Primary Issues Addressed
 * Support for Mind Scape workbench files
 
 ### Version 1.2.1
-[Issues closed in milestone 1.2.1](https://github.com/jaredpar/VsVim/issues?milestone=24&state=closed)
+[Issues closed in milestone 1.2.1](https://github.com/VsVim/VsVim/issues?milestone=24&state=closed)
 
 Primary Issues Addressed
 
@@ -236,7 +236,7 @@ Primary Issues Addressed
 * Repeating commands resulted in intellisense being displayed
 
 ### Version 1.2
-[Issues closed in milestone 1.2](https://github.com/jaredpar/VsVim/issues?milestone=20&state=closed)
+[Issues closed in milestone 1.2](https://github.com/VsVim/VsVim/issues?milestone=20&state=closed)
 
 Primary Issues Addressed
 
@@ -251,7 +251,7 @@ Primary Issues Addressed
 * Continued performance tuning of :hlsearch
 
 ### Version 1.1.2
-[Issues closed in milestone 1.1.2](https://github.com/jaredpar/VsVim/issues?sort=created&direction=desc&state=closed&page=1&milestone=22)
+[Issues closed in milestone 1.1.2](https://github.com/VsVim/VsVim/issues?sort=created&direction=desc&state=closed&page=1&milestone=22)
 
 Primary Issues Addressed
 
@@ -261,7 +261,7 @@ Primary Issues Addressed
 * Tab on new line inserts tab on previous line
 
 ### Version 1.1.1
-[Issues closed in milestone 1.1.1](https://github.com/jaredpar/VsVim/issues?milestone=19&sort=created&direction=desc&state=closed)
+[Issues closed in milestone 1.1.1](https://github.com/VsVim/VsVim/issues?milestone=19&sort=created&direction=desc&state=closed)
 
 Primary Issues Addressed
 
@@ -278,7 +278,7 @@ Primary Issues Addressed
 * VsVim not running on machines with only Visual Studio 11 installed
 
 ### Version 1.1.0
-[Issues closed in milestone 1.1](https://github.com/jaredpar/VsVim/issues?sort=created&direction=desc&state=closed&page=1&milestone=10)
+[Issues closed in milestone 1.1](https://github.com/VsVim/VsVim/issues?sort=created&direction=desc&state=closed&page=1&milestone=10)
 
 Primary Issues Addressed
 
@@ -290,7 +290,7 @@ Primary Issues Addressed
 * Support added for Dev11 preview
 
 ### Version 1.0.3
-[Issues closed in milestone 1.0.3](https://github.com/jaredpar/VsVim/issues?milestone=17&state=closed)
+[Issues closed in milestone 1.0.3](https://github.com/VsVim/VsVim/issues?milestone=17&state=closed)
 
 Primary Issues Addressed
 
@@ -299,7 +299,7 @@ Primary Issues Addressed
 * Enter and Back were causing issues with R# in certain scenarios
 
 ### Version 1.0.2
-[Issues closed in milestone 1.0.2](https://github.com/jaredpar/VsVim/issues?milestone=16&state=closed)
+[Issues closed in milestone 1.0.2](https://github.com/VsVim/VsVim/issues?milestone=16&state=closed)
 
 Primary Issues Addressed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AppVeyor Status: [![Build status](https://ci.appveyor.com/api/projects/status/gf
 
 This project requires Visual Studio 2017 or 2019 to be edited.  Make sure to install the F# and Visual Studio extension work load. 
 
-When developing please follow the [coding guidelines](https://github.com/jaredpar/VsVim/blob/master/Documentation/CodingGuidelines.md)
+When developing please follow the [coding guidelines](https://github.com/VsVim/VsVim/blob/master/Documentation/CodingGuidelines.md)
 
 ## License
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -235,7 +235,7 @@ type internal CommonOperations
     /// accessible in the property bag of the ITextUndoHistory object. In 2017 and before this was added
     /// during AfterTextBufferChangeUndoPrimitive.Create. In 2019 this stopped happening and hence undo /
     /// redo is broken. Forcing it to be present here. 
-    /// https://github.com/jaredpar/VsVim/issues/2463
+    /// https://github.com/VsVim/VsVim/issues/2463
     member x.EnsureUndoHasView() =
         match _undoRedoOperations.TextUndoHistory with
         | None -> ()

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1201,7 +1201,7 @@ type VimInterpreter
         _commonOperations.GoToNextTab SearchPath.Backward count
 
     member x.RunHelp () = 
-        _statusUtil.OnStatus "For help on VsVim, please visit the Wiki page (https://github.com/jaredpar/VsVim/wiki)"
+        _statusUtil.OnStatus "For help on VsVim, please visit the Wiki page (https://github.com/VsVim/VsVim/wiki)"
 
     /// Print out the applicable history information
     member x.RunHistory () = 

--- a/Src/VimTestUtils/Exports/VimErrorHandler.cs
+++ b/Src/VimTestUtils/Exports/VimErrorHandler.cs
@@ -121,7 +121,7 @@ namespace Vim.UnitTest.Exports
         void IExtensionErrorHandler.HandleError(object sender, Exception exception)
         {
 #if VSVIM_DEV_2019
-            // https://github.com/jaredpar/VsVim/issues/2463
+            // https://github.com/VsVim/VsVim/issues/2463
             // Working around several bugs thrown during core MEF composition
             if (exception.Message.Contains("Microsoft.VisualStudio.Language.CodeCleanUp.CodeCleanUpFixerRegistrationService.ProfileService") ||
                 exception.Message.Contains("Microsoft.VisualStudio.Language.CodeCleanUp.CodeCleanUpFixerRegistrationService.mefRegisteredCodeCleanupProviders") ||

--- a/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
+++ b/Src/VimWpf/Implementation/BlockCaret/BlockCaret.cs
@@ -181,8 +181,8 @@ namespace Vim.UI.Wpf.Implementation.BlockCaret
         ///
         /// Either way though need to guard against this case to unblock users.
         /// 
-        /// https://github.com/jaredpar/VsVim/issues/631
-        /// https://github.com/jaredpar/VsVim/issues/1860
+        /// https://github.com/VsVim/VsVim/issues/631
+        /// https://github.com/VsVim/VsVim/issues/1860
         /// </summary>
         private static DispatcherTimer CreateBlinkTimer(IProtectedOperations protectedOperations, EventHandler onCaretBlinkTimer)
         {

--- a/Src/VsVim/source.extension.vsixmanifest
+++ b/Src/VsVim/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
     <Identity Publisher="Jared Parsons" Version="2.7.0.0" Id="VsVim.Microsoft.e214908b-0458-4ae2-a583-4310f29687c3" Language="en-US" />
     <DisplayName>VsVim</DisplayName>
     <Description>VIM emulation layer for Visual Studio</Description>
-    <MoreInfo>https://github.com/jaredpar/VsVim</MoreInfo>
+    <MoreInfo>https://github.com/VsVim/VsVim</MoreInfo>
     <License>License.txt</License>
     <Icon>VsVim_large.png</Icon>
     <PreviewImage>VsVim_small.png</PreviewImage>

--- a/Src/VsVimShared/Implementation/UpgradeNotification/VimRcLoadNotificationMarginProvider.cs
+++ b/Src/VsVimShared/Implementation/UpgradeNotification/VimRcLoadNotificationMarginProvider.cs
@@ -88,7 +88,7 @@ namespace Vim.VisualStudio.Implementation.UpgradeNotification
             {
                 var linkBanner = new LinkBanner
                 {
-                    LinkAddress = "https://github.com/jaredpar/VsVim/wiki/FAQ#vimrc",
+                    LinkAddress = "https://github.com/VsVim/VsVim/wiki/FAQ#vimrc",
                     LinkText = "FAQ",
                     BannerText = "VsVim automatically loaded an existing _vimrc file"
                 };

--- a/Src/VsVimShared/Implementation/VisualAssist/VisualAssistMargin.xaml
+++ b/Src/VsVimShared/Implementation/VisualAssist/VisualAssistMargin.xaml
@@ -13,7 +13,7 @@
             <Label>Visual Assist needs a setting change to enable VsVim support.</Label>
             <Hyperlink 
                 Name="_faqHyperlink"
-                NavigateUri="https://github.com/jaredpar/VsVim/wiki/FAQ#wiki-vax"
+                NavigateUri="https://github.com/VsVim/VsVim/wiki/FAQ#wiki-vax"
                 RequestNavigate="OnRequestNavigate"
                 BaselineAlignment="Center">FAQ Entry</Hyperlink>
         </TextBlock>

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -338,7 +338,7 @@ namespace Vim.VisualStudio
             // The output window is not guaraneed to be accessible on startup. On certain configurations of VS2015
             // it can throw an exception. Delaying the creation of the Window until after startup has likely 
             // completed. Additionally using IProtectedOperations to guard against exeptions 
-            // https://github.com/jaredpar/VsVim/issues/2249
+            // https://github.com/VsVim/VsVim/issues/2249
 
             _protectedOperations.BeginInvoke(initOutputPaneCore, DispatcherPriority.ApplicationIdle);
 

--- a/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
+++ b/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
@@ -251,7 +251,7 @@ namespace Vim.UnitTest
             }
 
 #if VSVIM_DEV_2017
-            // https://github.com/jaredpar/VsVim/issues/2463
+            // https://github.com/VsVim/VsVim/issues/2463
             /// <summary>
             /// If the caret is in the selection exclusive and we're in visual mode then we should leave
             /// the caret in the line break.  It's needed to let motions like v$ get the appropriate 
@@ -273,7 +273,7 @@ namespace Vim.UnitTest
                 }
             }
 #elif VSVIM_DEV_2019
-            // https://github.com/jaredpar/VsVim/issues/2463
+            // https://github.com/VsVim/VsVim/issues/2463
 #else
 #error Unsupported configuration
 #endif

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -1023,7 +1023,7 @@ namespace Vim.UnitTest
             {
                 Create("");
                 ParseAndRun(@"help");
-                Assert.Contains("https://github.com/jaredpar/VsVim/wiki", _statusUtil.LastStatus);
+                Assert.Contains("https://github.com/VsVim/VsVim/wiki", _statusUtil.LastStatus);
             }
 
             [WpfFact]
@@ -1031,7 +1031,7 @@ namespace Vim.UnitTest
             {
                 Create("");
                 ParseAndRun(@"help :vsc");
-                Assert.Contains("https://github.com/jaredpar/VsVim/wiki", _statusUtil.LastStatus);
+                Assert.Contains("https://github.com/VsVim/VsVim/wiki", _statusUtil.LastStatus);
             }
         }
 

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -7849,7 +7849,7 @@ namespace Vim.UnitTest
             /// <summary>
             /// See the full discussion in issue #509
             ///
-            /// https://github.com/jaredpar/VsVim/issues/509
+            /// https://github.com/VsVim/VsVim/issues/509
             ///
             /// Make sure that doing a ""][" from the middle of the line ends on the '}' if it is
             /// preceded by a blank line

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -1039,7 +1039,7 @@ namespace Vim.UnitTest
                 /// <summary>
                 /// The 'e' motion should select up to and including the end of the word
                 ///
-                /// https://github.com/jaredpar/VsVim/issues/568
+                /// https://github.com/VsVim/VsVim/issues/568
                 /// </summary>
                 [WpfFact]
                 public void EndOfWordMotion()


### PR DESCRIPTION
Because VsVim moved to the organization,I correct the link.
Even in the present situation it will be redirected correctly,
I corrected it just in case.
And the link below still seems to be a personal name.

[https://ci.appveyor.com/project/jaredpar/vsvim](https://ci.appveyor.com/project/jaredpar/vsvim)
