### PR TITLE
Fix ASCII control character processing on international keyboards

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1403,7 +1403,7 @@ type KeyInputSet
         while not current.IsEmpty do
             hashCode <- 
                 if hashCode = 1 then current.Head.GetHashCode()
-                else hashCode ^^^ current.Head.GetHashCode()
+                else HashUtil.Combine2 hashCode (current.Head.GetHashCode())
             current <- current.Tail
         hashCode
 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -5490,6 +5490,20 @@ module VimExtensions =
         modeKind = ModeKind.Insert ||
         modeKind = ModeKind.Replace
 
+    /// Is this ModeKind any type of Visual
+    [<Extension>]
+    let IsAnyVisual modeKind = 
+        modeKind = ModeKind.VisualCharacter ||
+        modeKind = ModeKind.VisualLine ||
+        modeKind = ModeKind.VisualBlock
+
+    /// Is this ModeKind any type of Select
+    [<Extension>]
+    let IsAnySelect modeKind = 
+        modeKind = ModeKind.SelectCharacter ||
+        modeKind = ModeKind.SelectLine ||
+        modeKind = ModeKind.SelectBlock
+
 module internal VimCoreExtensions =
     
     type IVim with

--- a/Src/VimCore/DisabledMode.fs
+++ b/Src/VimCore/DisabledMode.fs
@@ -8,11 +8,11 @@ type internal DisabledMode(_vimBufferData: IVimBufferData) =
     let _globalSettings = _localSettings.GlobalSettings
     
     member x.HelpString = 
-        let ki = _globalSettings.DisableAllCommand
-        if VimKeyModifiers.None = ki.KeyModifiers then 
-            sprintf "Vim Disabled. Type %s to re-enable" (ki.Key.ToString())
+        let keyInput = _globalSettings.DisableAllCommand
+        if VimKeyModifiers.None = keyInput.KeyModifiers then 
+            sprintf "Vim Disabled. Type %s to re-enable" (keyInput.Key.ToString())
         else
-            sprintf "Vim Disabled. Type %s+%s to re-enable" (ki.Key.ToString()) (ki.KeyModifiers.ToString())
+            sprintf "Vim Disabled. Type %s+%s to re-enable" (keyInput.Key.ToString()) (keyInput.KeyModifiers.ToString())
 
     member x.Process keyInput = 
         if keyInput = _globalSettings.DisableAllCommand then
@@ -25,7 +25,7 @@ type internal DisabledMode(_vimBufferData: IVimBufferData) =
         member x.HelpMessage = x.HelpString
         member x.ModeKind = ModeKind.Disabled        
         member x.CommandNames = Seq.singleton (KeyInputSet(_globalSettings.DisableAllCommand))
-        member x.CanProcess ki = ki = _globalSettings.DisableAllCommand
+        member x.CanProcess keyInput = keyInput = _globalSettings.DisableAllCommand
         member x.Process keyInput = x.Process keyInput
         member x.OnEnter _  = ()
         member x.OnLeave() = ()

--- a/Src/VimCore/ExternalEdit.fs
+++ b/Src/VimCore/ExternalEdit.fs
@@ -8,9 +8,9 @@ type internal ExternalEditMode(_vimBufferData: IVimBufferData) =
         member x.VimTextBuffer = _vimBufferData.VimTextBuffer
         member x.ModeKind = ModeKind.ExternalEdit
         member x.CommandNames = Seq.empty
-        member x.CanProcess ki = ki = KeyInputUtil.EscapeKey
-        member x.Process ki = 
-            if ki = KeyInputUtil.EscapeKey then
+        member x.CanProcess keyInput = keyInput = KeyInputUtil.EscapeKey
+        member x.Process keyInput = 
+            if keyInput = KeyInputUtil.EscapeKey then
                 ProcessResult.OfModeKind ModeKind.Normal
             else
                 ProcessResult.NotHandled

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -559,7 +559,7 @@ module CharUtil =
     let IsWhiteSpace x = System.Char.IsWhiteSpace(x)
     let IsNotWhiteSpace x = not (System.Char.IsWhiteSpace(x))
     let IsControl x = System.Char.IsControl x
-    let IsAscii x = x >= 0 && x <= 127
+    let IsAscii x = x >= '\u0000' && x <= '\u00ff'
 
     /// Is this the Vim definition of a blank character.  That is it a space
     /// or tab

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -559,6 +559,7 @@ module CharUtil =
     let IsWhiteSpace x = System.Char.IsWhiteSpace(x)
     let IsNotWhiteSpace x = not (System.Char.IsWhiteSpace(x))
     let IsControl x = System.Char.IsControl x
+    let IsAscii x = x >= 0 && x <= 127
 
     /// Is this the Vim definition of a blank character.  That is it a space
     /// or tab

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -375,7 +375,7 @@ module internal GenericListUtil =
     let OfSeq (col: 'T seq) = System.Collections.Generic.List<'T>(col)
 
 [<RequireQualifiedAccess>]
-type internal CharComparer =
+type CharComparer =
     | Exact
     | IgnoreCase
 
@@ -510,7 +510,7 @@ type internal CharSpan
         let length = endIndex - startIndex
         CharSpan(str, startIndex, length, charComparer)
 
-module internal CharUtil =
+module CharUtil =
 
     let PrintableCategories =
         seq {

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -467,14 +467,16 @@ module KeyInputUtil =
         | _ -> None
 
     let IsCore (keyInput: KeyInput) =
-        if not keyInput.HasKeyModifiers then
-            if keyInput.Key <> VimKey.RawCharacter then
-                // Any standard vim key without modifiers is a core key input.
-                true
-            elif Option.isSome keyInput.RawChar && VimKeyCharSet.Contains keyInput.Char then
-                // Any standard vim char without modifiers is a core key input.
-                true
-            else
-                false
+        if Util.IsFlagSet keyInput.KeyModifiers VimKeyModifiers.Alt then
+            // No key or char with the alt modifier is a core key input.
+            false
+        elif keyInput.Key <> VimKey.RawCharacter then
+            // Any standard vim key with or without modifiers is a core key input, with some exceptions.
+            match keyInput with
+            | keyInput when keyInput = ApplyKeyModifiers TabKey VimKeyModifiers.Control -> false
+            | _ -> true
+        elif not keyInput.HasKeyModifiers && Option.isSome keyInput.RawChar && VimKeyCharSet.Contains keyInput.Char then
+            // Any standard vim char without modifiers is a core key input.
+            true
         else
             false

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -51,7 +51,7 @@ type KeyInput
                 else compare left.Key right.Key
                     
     override x.GetHashCode() = 
-        x.Char.GetHashCode() ^^^ x.Key.GetHashCode() ^^^ x.KeyModifiers.GetHashCode()
+        HashUtil.Combine3 (x.Char.GetHashCode()) (x.Key.GetHashCode()) (x.KeyModifiers.GetHashCode())
 
     override x.Equals(obj) =
         match obj with

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -22,6 +22,9 @@ type KeyInput =
     /// The extra modifier keys applied to the VimKey value
     member KeyModifiers: VimKeyModifiers
 
+    /// Whether the key has any key modifiers
+    member HasKeyModifiers: bool
+
     /// Is the character for this KeyInput a digit
     member IsDigit: bool
 
@@ -71,7 +74,10 @@ module KeyInputUtil =
     /// The KeyInput for every VimKey in the system which is considered predefined
     val VimKeyInputList: KeyInput list
 
-    /// The set of core characters as a seq
+    /// The set of core characters
+    val VimKeyCharSet: char Set
+
+    /// The set of core characters as a list
     val VimKeyCharList: char list
 
     /// Apply the modifiers to the given KeyInput and determine the result.  This will
@@ -114,4 +120,7 @@ module KeyInputUtil =
 
     /// Get the alternate key for the given KeyInput if it's a key from the keypad 
     val GetNonKeypadEquivalent: keyInput: KeyInput -> KeyInput option 
+
+    /// Whether this key input could appear in vim's standard bindings
+    val IsCore: keyInput: KeyInput -> bool
 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -170,7 +170,7 @@ type internal CommandMode
         member x.CommandNames = HistoryUtil.CommandNames |> Seq.map KeyInputSetUtil.Single
         member x.InPasteWait = x.InPasteWait
         member x.ModeKind = ModeKind.Command
-        member x.CanProcess keyInput = not keyInput.IsMouseKey
+        member x.CanProcess keyInput = KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
         member x.Process keyInput = x.Process keyInput
         member x.OnEnter arg = x.OnEnter arg
         member x.OnLeave () = x.OnLeave ()

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -518,9 +518,7 @@ type internal InsertMode
                     // is never a direct insert. But on some international
                     // keyboards, it might translate to an ASCII control
                     // character. See issue #2462.
-                    match Map.tryFind keyInput _commandMap with
-                    | Some rawInsertCommand -> Some rawInsertCommand
-                    | None -> None
+                    None
 
                 else if keyInput.HasKeyModifiers && not (CharUtil.IsLetterOrDigit c) then
 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -511,12 +511,12 @@ type internal InsertMode
                     let keyInputSet = KeyInputSet(keyInput)
                     RawInsertCommand.InsertCommand (keyInputSet, command, commandFlags) |> Some
 
-                if keyInput.KeyModifiers = VimKeyModifiers.Control && not (CharUtil.IsLetterOrDigit c) then
+                if keyInput.KeyModifiers = VimKeyModifiers.Control then
 
-                    // A non-letter, non-digit key with only control that isn't
-                    // mapped is never a direct insert. But on some
-                    // international keyboards, it might translate to an ASCII
-                    // control character. See issue #2462.
+                    // A key with only control pressed that isn't mapped is
+                    // never a direct insert. But on some international
+                    // keyboards, it might translate to an ASCII control
+                    // character. See issue #2462.
                     match Map.tryFind keyInput _commandMap with
                     | Some rawInsertCommand -> Some rawInsertCommand
                     | None -> None

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -511,10 +511,12 @@ type internal InsertMode
                     let keyInputSet = KeyInputSet(keyInput)
                     RawInsertCommand.InsertCommand (keyInputSet, command, commandFlags) |> Some
 
-                if keyInput.KeyModifiers = VimKeyModifiers.Control then
+                if keyInput.KeyModifiers = VimKeyModifiers.Control && not (CharUtil.IsLetterOrDigit c) then
 
-                    // Keys with only control that aren't mapped are never
-                    // direct input.
+                    // A non-letter, non-digit key with only control that isn't
+                    // mapped is never a direct insert. But on some
+                    // international keyboards, it might translate to an ASCII
+                    // control character. See issue #2462.
                     match Map.tryFind keyInput _commandMap with
                     | Some rawInsertCommand -> Some rawInsertCommand
                     | None -> None

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -452,7 +452,8 @@ type internal InsertMode
         | _ -> ()
 
     /// Can Insert mode handle this particular KeyInput value 
-    member x.CanProcess keyInput = x.GetRawInsertCommand keyInput |> Option.isSome
+    member x.CanProcess keyInput =
+        x.GetRawInsertCommand keyInput |> Option.isSome
 
     /// Complete the current batched edit command if one exists
     member x.CompleteCombinedEditCommand keyInput = 
@@ -513,15 +514,15 @@ type internal InsertMode
 
                 if keyInput.KeyModifiers = VimKeyModifiers.Control then
 
-                    // A key with only control pressed that isn't mapped is
-                    // never a direct insert. But on some international
+                    // A key with only the control modifier that isn't mapped
+                    // is never a direct insert. But on some international
                     // keyboards, it might translate to an ASCII control
                     // character. See issue #2462.
                     match Map.tryFind keyInput _commandMap with
                     | Some rawInsertCommand -> Some rawInsertCommand
                     | None -> None
 
-                else if keyInput.KeyModifiers <> VimKeyModifiers.None && not (CharUtil.IsLetterOrDigit c) then
+                else if keyInput.HasKeyModifiers && not (CharUtil.IsLetterOrDigit c) then
 
                     // Certain keys such as Delete, Esc, etc ... have the same
                     // behavior when invoked with or without any modifiers.

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -33,9 +33,6 @@ type internal NormalMode
         InReplace = false
     }
 
-    /// Set of all char's Vim is interested in 
-    let _coreCharSet = KeyInputUtil.VimKeyCharList |> Set.ofList
-
     /// Contains the state information for Normal mode
     let mutable _data = EmptyData
 
@@ -359,17 +356,8 @@ type internal NormalMode
         _data <- EmptyData
 
     member x.CanProcess (keyInput: KeyInput) =
-        if _runner.IsWaitingForMoreInput then 
-            true
-        elif _runner.DoesCommandStartWith keyInput then
-            true
-        elif Option.isSome keyInput.RawChar && keyInput.KeyModifiers = VimKeyModifiers.None then
-
-            // We can process any printable character (think international input)
-            // or any character which is part of the standard Vim input set.
-            Set.contains keyInput.Char _coreCharSet
-        else 
-            false
+        _runner.IsWaitingForMoreInput
+        || _runner.DoesCommandStartWith keyInput
     
     member x.Process (keyInput: KeyInput) = 
 

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -33,6 +33,9 @@ type internal NormalMode
         InReplace = false
     }
 
+    /// Set of all char's Vim is interested in
+    let _coreCharSet = KeyInputUtil.VimKeyCharList |> Set.ofList
+
     /// Contains the state information for Normal mode
     let mutable _data = EmptyData
 
@@ -356,8 +359,17 @@ type internal NormalMode
         _data <- EmptyData
 
     member x.CanProcess (keyInput: KeyInput) =
-        _runner.IsWaitingForMoreInput
-        || _runner.DoesCommandStartWith keyInput
+        if _runner.IsWaitingForMoreInput then
+            true
+        elif _runner.DoesCommandStartWith keyInput then
+            true
+        elif Option.isSome keyInput.RawChar && keyInput.KeyModifiers = VimKeyModifiers.None then
+
+            // We can process any character which is part of the standard Vim
+            // input set.
+            Set.contains keyInput.Char _coreCharSet
+        else
+            false
     
     member x.Process (keyInput: KeyInput) = 
 

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -363,11 +363,11 @@ type internal NormalMode
             true
         elif _runner.DoesCommandStartWith keyInput then
             true
-        elif Option.isSome keyInput.RawChar && VimKeyModifiers.None = keyInput.KeyModifiers then
+        elif Option.isSome keyInput.RawChar && keyInput.KeyModifiers = VimKeyModifiers.None then
 
             // We can process any printable character (think international input)
             // or any character which is part of the standard Vim input set.
-            CharUtil.IsPrintable keyInput.Char || Set.contains keyInput.Char _coreCharSet
+            Set.contains keyInput.Char _coreCharSet
         else 
             false
     

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -33,9 +33,6 @@ type internal NormalMode
         InReplace = false
     }
 
-    /// Set of all char's Vim is interested in
-    let _coreCharSet = KeyInputUtil.VimKeyCharList |> Set.ofList
-
     /// Contains the state information for Normal mode
     let mutable _data = EmptyData
 
@@ -359,17 +356,8 @@ type internal NormalMode
         _data <- EmptyData
 
     member x.CanProcess (keyInput: KeyInput) =
-        if _runner.IsWaitingForMoreInput then
-            true
-        elif _runner.DoesCommandStartWith keyInput then
-            true
-        elif Option.isSome keyInput.RawChar && keyInput.KeyModifiers = VimKeyModifiers.None then
-
-            // We can process any character which is part of the standard Vim
-            // input set.
-            Set.contains keyInput.Char _coreCharSet
-        else
-            false
+        KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
+        || _runner.DoesCommandStartWith keyInput
     
     member x.Process (keyInput: KeyInput) = 
 

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -65,7 +65,8 @@ type internal SubstituteConfirmMode
 
     member x.CurrentSnapshot = _textBuffer.CurrentSnapshot
 
-    member x.CanProcess (keyInput: KeyInput) = not keyInput.IsMouseKey
+    member x.CanProcess (keyInput: KeyInput) =
+        KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
 
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
 

--- a/Src/VimCore/Modes_Visual_SelectMode.fs
+++ b/Src/VimCore/Modes_Visual_SelectMode.fs
@@ -178,7 +178,9 @@ type internal SelectMode
             ProcessResult.Handled (ModeSwitch.SwitchMode ModeKind.Insert)
 
     member x.CanProcess (keyInput: KeyInput) =
-        not keyInput.IsMouseKey || _runner.DoesCommandStartWith keyInput
+        keyInput.Key <> VimKey.None
+        || keyInput.KeyModifiers = VimKeyModifiers.None && CharUtil.IsPrintable(keyInput.Char)
+        || _runner.DoesCommandStartWith keyInput
 
     member x.Process keyInput = 
 

--- a/Src/VimCore/Modes_Visual_SelectMode.fs
+++ b/Src/VimCore/Modes_Visual_SelectMode.fs
@@ -178,8 +178,7 @@ type internal SelectMode
             ProcessResult.Handled (ModeSwitch.SwitchMode ModeKind.Insert)
 
     member x.CanProcess (keyInput: KeyInput) =
-        keyInput.Key <> VimKey.None
-        || keyInput.KeyModifiers = VimKeyModifiers.None && CharUtil.IsPrintable(keyInput.Char)
+        KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
         || _runner.DoesCommandStartWith keyInput
 
     member x.Process keyInput = 

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -156,7 +156,8 @@ type internal VisualMode
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
 
     member x.CanProcess (keyInput: KeyInput) =
-        not keyInput.IsMouseKey || _runner.DoesCommandStartWith keyInput
+        keyInput = KeyInputUtil.EscapeKey && x.ShouldHandleEscape
+        || _runner.DoesCommandStartWith keyInput
 
     member x.CommandNames = 
         x.EnsureCommandsBuilt()

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -156,8 +156,8 @@ type internal VisualMode
     member x.CaretPoint = TextViewUtil.GetCaretPoint _textView
 
     member x.CanProcess (keyInput: KeyInput) =
-        keyInput = KeyInputUtil.EscapeKey && x.ShouldHandleEscape
-        || _runner.DoesCommandStartWith keyInput
+        KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
+        ||_runner.DoesCommandStartWith keyInput
 
     member x.CommandNames = 
         x.EnsureCommandsBuilt()

--- a/Src/VimCore/StringUtil.fs
+++ b/Src/VimCore/StringUtil.fs
@@ -4,7 +4,7 @@ namespace Vim
 open System
 open StringBuilderExtensions
 
-module internal StringUtil =
+module StringUtil =
 
     let Empty = System.String.Empty
 

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -303,6 +303,9 @@ type internal VimBuffer
             match x.Mode.ModeKind with
             | ModeKind.Insert -> x.InsertMode.IsDirectInsert keyInput
             | ModeKind.Replace -> x.ReplaceMode.IsDirectInsert keyInput
+            | ModeKind.SelectCharacter -> x.InsertMode.IsDirectInsert keyInput
+            | ModeKind.SelectLine -> x.InsertMode.IsDirectInsert keyInput
+            | ModeKind.SelectBlock -> x.InsertMode.IsDirectInsert keyInput
             | _ -> false
 
         // Can the given KeyInput be processed as a command or potentially a 

--- a/Src/VimWpf/VimKeyProcessor.cs
+++ b/Src/VimWpf/VimKeyProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Windows.Input;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -63,7 +64,11 @@ namespace Vim.UI.Wpf
         /// </summary>
         public override void TextInput(TextCompositionEventArgs args)
         {
-            VimTrace.TraceInfo("VimKeyProcessor::TextInput Text={0} ControlText={1} SystemText={2}", args.Text, args.ControlText, args.SystemText);
+            VimTrace.TraceInfo("VimKeyProcessor::TextInput Text={0} ControlText={1} SystemText={2}",
+                GetDisplayString(args.Text),
+                GetDisplayString(args.ControlText),
+                GetDisplayString(args.SystemText));
+
             var handled = false;
 
             var text = args.Text;
@@ -164,6 +169,30 @@ namespace Vim.UI.Wpf
             VimTrace.TraceInfo("VimKeyProcessor::KeyUp {0} {1}", args.Key, args.KeyboardDevice.Modifiers);
             VimTrace.TraceInfo("VimKeyProcessor::KeyUp Handled = {0}", args.Handled);
             base.KeyUp(args);
+        }
+
+        /// <summary>
+        /// Convert a string possibly containing control characters to one
+        /// suitable for display in a log message
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        private string GetDisplayString(string s)
+        {
+            var builder = new StringBuilder();
+            foreach (var c in s)
+            {
+                if (char.IsControl(c))
+                {
+                    builder.Append('^');
+                    builder.Append((char)(c + '@'));
+                }
+                else
+                {
+                    builder.Append(c);
+                }
+            }
+            return builder.ToString();
         }
     }
 }

--- a/Src/VimWpf/VimKeyProcessor.cs
+++ b/Src/VimWpf/VimKeyProcessor.cs
@@ -65,9 +65,9 @@ namespace Vim.UI.Wpf
         public override void TextInput(TextCompositionEventArgs args)
         {
             VimTrace.TraceInfo("VimKeyProcessor::TextInput Text={0} ControlText={1} SystemText={2}",
-                GetDisplayString(args.Text),
-                GetDisplayString(args.ControlText),
-                GetDisplayString(args.SystemText));
+                StringUtil.GetDisplayString(args.Text),
+                StringUtil.GetDisplayString(args.ControlText),
+                StringUtil.GetDisplayString(args.SystemText));
 
             var handled = false;
 
@@ -169,30 +169,6 @@ namespace Vim.UI.Wpf
             VimTrace.TraceInfo("VimKeyProcessor::KeyUp {0} {1}", args.Key, args.KeyboardDevice.Modifiers);
             VimTrace.TraceInfo("VimKeyProcessor::KeyUp Handled = {0}", args.Handled);
             base.KeyUp(args);
-        }
-
-        /// <summary>
-        /// Convert a string possibly containing control characters to one
-        /// suitable for display in a log message
-        /// </summary>
-        /// <param name="s"></param>
-        /// <returns></returns>
-        private string GetDisplayString(string s)
-        {
-            var builder = new StringBuilder();
-            foreach (var c in s)
-            {
-                if (char.IsControl(c))
-                {
-                    builder.Append('^');
-                    builder.Append((char)(c + '@'));
-                }
-                else
-                {
-                    builder.Append(c);
-                }
-            }
-            return builder.ToString();
         }
     }
 }

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -360,6 +360,17 @@ namespace Vim.VisualStudio.Implementation.Misc
                         {
                             return true;
                         }
+
+                        // Discard any other unprocessed input in non-input
+                        // modes. Without this, Visual Studio will see the
+                        // command as unhandled and will try to handle it
+                        // itself by inserting the character into the buffer.
+                        if (editCommand.EditCommandKind == EditCommandKind.UserInput &&
+                            !_vimBuffer.ModeKind.IsAnyInsert() &&
+                            !_vimBuffer.ModeKind.IsAnySelect())
+                        {
+                            return true;
+                        }
                     }
                     return false;
                 default:

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -364,13 +364,14 @@ namespace Vim.VisualStudio.Implementation.Misc
                             return true;
                         }
 
-                        // Discard any other unprocessed input in non-input
-                        // modes. Without this, Visual Studio will see the
-                        // command as unhandled and will try to handle it
-                        // itself by inserting the character into the buffer.
+                        // Discard any other unprocessed printable input in
+                        // non-input modes. Without this, Visual Studio will
+                        // see the command as unhandled and will try to handle
+                        // it itself by inserting the character into the
+                        // buffer.
                         if (editCommand.EditCommandKind == EditCommandKind.UserInput &&
-                            !_vimBuffer.ModeKind.IsAnyInsert() &&
-                            !_vimBuffer.ModeKind.IsAnySelect())
+                            CharUtil.IsPrintable(keyInput.Char) &&
+                            (_vimBuffer.ModeKind == ModeKind.Normal || _vimBuffer.ModeKind.IsAnyVisual()))
                         {
                             _commonOperations.Beep();
                             return true;

--- a/Src/VsVimShared/Implementation/Misc/VsVimKeyProcessor.cs
+++ b/Src/VsVimShared/Implementation/Misc/VsVimKeyProcessor.cs
@@ -68,14 +68,14 @@ namespace Vim.VisualStudio.Implementation.Misc
                 return false;
             }
 
-            // In insert mode we don't want text input going directly to VsVim.  Text input must
+            // In insert modes we don't want text input going directly to VsVim.  Text input must
             // be routed through Visual Studio and IOleCommandTarget in order to get intellisense
             // properly hooked up.  Not handling it in this KeyProcessor will eventually cause
             // it to be routed through IOleCommandTarget if it's input
             //
             // The Visual Studio KeyProcessor won't pass along control characters that are less than
             // or equal to 0x1f so we have to handle them here 
-            if (VimBuffer.ModeKind.IsAnyInsert() &&
+            if ((VimBuffer.ModeKind.IsAnyInsert() || VimBuffer.ModeKind.IsAnySelect()) &&
                 !VimBuffer.CanProcessAsCommand(keyInput) &&
                 (int)keyInput.Char > 0x1f)
             {

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -158,11 +158,14 @@ namespace Vim.UnitTest
             Assert.True(_mode.CanProcess(KeyInputUtil.TabKey));
         }
 
+        /// <summary>
+        /// WPF window level shortcuts shouldn't be processed (for the benefit of VimApp)
+        /// </summary>
         [WpfFact]
         public void CanProcess_DontHandleControlTab()
         {
             Create("");
-            Assert.False(_mode.CanProcess(KeyInputUtil.ChangeKeyModifiersDangerous(KeyInputUtil.TabKey, VimKeyModifiers.Control)));
+            Assert.False(_mode.CanProcess(KeyInputUtil.ApplyKeyModifiers(KeyInputUtil.TabKey, VimKeyModifiers.Control)));
         }
 
         /// <summary>

--- a/Test/VimCoreTest/NormalModeTest.cs
+++ b/Test/VimCoreTest/NormalModeTest.cs
@@ -166,19 +166,18 @@ namespace Vim.UnitTest
         }
 
         /// <summary>
-        /// Must be able to process non-ASCII punctuation otherwise
-        /// they will end up as input
+        /// Non-ASCII characters should not be reported as being able to be
+        /// processed by normal mode
         /// </summary>
         [WpfFact]
-        public void CanProcessPrintableNonAscii()
+        public void CanProcess_PrintableNonAscii()
         {
-            // Reported in issue #1793.
             Create(s_defaultLines);
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('¤')));
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('¨')));
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('£')));
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('§')));
-            Assert.True(_mode.CanProcess(KeyInputUtil.CharToKeyInput('´')));
+            Assert.False(_mode.CanProcess(KeyInputUtil.CharToKeyInput('¤')));
+            Assert.False(_mode.CanProcess(KeyInputUtil.CharToKeyInput('¨')));
+            Assert.False(_mode.CanProcess(KeyInputUtil.CharToKeyInput('£')));
+            Assert.False(_mode.CanProcess(KeyInputUtil.CharToKeyInput('§')));
+            Assert.False(_mode.CanProcess(KeyInputUtil.CharToKeyInput('´')));
         }
 
         #endregion

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -1055,13 +1055,14 @@ namespace Vim.UnitTest
                 _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
 
                 // <F4> is not a valid command
-                Assert.False(_vimBuffer.CanProcess(VimKey.F4));
+                var keyInput = KeyInputUtil.CharToKeyInput('¤');
+                Assert.False(_vimBuffer.CanProcess(keyInput));
                 _vimBuffer.Process("l");
                 Assert.False(_vimBuffer.BufferedKeyInputs.IsEmpty);
 
                 // Is is still not a valid command but when mapping is considered it will
                 // expand to l<F4> and l is a valid command
-                Assert.True(_vimBuffer.CanProcess(VimKey.F4));
+                Assert.True(_vimBuffer.CanProcess(keyInput));
             }
 
             /// <summary>

--- a/Test/VimCoreTest/VisualModeTest.cs
+++ b/Test/VimCoreTest/VisualModeTest.cs
@@ -123,7 +123,7 @@ namespace Vim.UnitTest
             var input = KeyInputUtil.CharToKeyInput('@');
             _operations.Setup(x => x.Beep()).Verifiable();
             Assert.DoesNotContain(_mode.CommandNames, x => x.KeyInputs.First().Char == input.Char);
-            Assert.True(_mode.CanProcess(input));
+            Assert.False(_mode.CanProcess(input));
             var ret = _mode.Process(input);
             Assert.True(ret.IsHandledNoSwitch());
             _operations.Verify();

--- a/Test/VimCoreTest/VisualModeTest.cs
+++ b/Test/VimCoreTest/VisualModeTest.cs
@@ -120,7 +120,7 @@ namespace Vim.UnitTest
         public void PreventInput1()
         {
             Create(lines: "foo");
-            var input = KeyInputUtil.CharToKeyInput('@');
+            var input = KeyInputUtil.CharToKeyInput('¤');
             _operations.Setup(x => x.Beep()).Verifiable();
             Assert.DoesNotContain(_mode.CommandNames, x => x.KeyInputs.First().Char == input.Char);
             Assert.False(_mode.CanProcess(input));

--- a/Test/VsVimSharedTest/Utils/VsSimulation.cs
+++ b/Test/VsVimSharedTest/Utils/VsSimulation.cs
@@ -256,6 +256,7 @@ namespace Vim.VisualStudio.UnitTest.Utils
         private readonly Mock<IDisplayWindowBroker> _displayWindowBroker;
         private readonly Mock<IReportDesignerUtil> _reportDesignerUtil;
         private readonly Mock<IVimApplicationSettings> _vimApplicationSettings;
+        private readonly Mock<ICommonOperations> _commonOperations;
         private readonly VsCommandTarget _vsCommandTarget;
         private readonly IKeyUtil _keyUtil;
         private readonly ReSharperCommandTargetSimulation _reSharperCommandTarget;
@@ -325,6 +326,8 @@ namespace Vim.VisualStudio.UnitTest.Utils
             _vimApplicationSettings.SetupGet(x => x.UseEditorIndent).Returns(true);
             _vimApplicationSettings.SetupGet(x => x.UseEditorTabAndBackspace).Returns(true);
 
+            _commonOperations = _factory.Create<ICommonOperations>();
+
             _vsSimulationCommandTarget = new SimulationCommandTarget(
                 bufferCoordinator.VimBuffer.TextView,
                 editorOperationsFactoryService.GetEditorOperations(bufferCoordinator.VimBuffer.TextView));
@@ -335,7 +338,12 @@ namespace Vim.VisualStudio.UnitTest.Utils
             {
                 commandTargets.Add(ReSharperKeyUtil.GetOrCreate(bufferCoordinator));
             }
-            commandTargets.Add(new StandardCommandTarget(bufferCoordinator, textManager.Object, _displayWindowBroker.Object, _vsSimulationCommandTarget));
+            commandTargets.Add(new StandardCommandTarget(
+                bufferCoordinator,
+                textManager.Object,
+                _commonOperations.Object,
+                _displayWindowBroker.Object,
+                _vsSimulationCommandTarget));
 
             // Create the VsCommandTarget.  It's next is the final and default Visual Studio 
             // command target

--- a/Test/VsVimSharedTest/VsCommandTargetTest.cs
+++ b/Test/VsVimSharedTest/VsCommandTargetTest.cs
@@ -359,7 +359,7 @@ namespace Vim.VisualStudio.UnitTest
             {
                 _commonOperations.Setup(x => x.Beep()).Verifiable();
                 _vimBuffer.SwitchMode(ModeKind.VisualCharacter, ModeArgument.None);
-                RunExec(KeyInputUtil.CharToKeyInput('@'));
+                RunExec(KeyInputUtil.CharToKeyInput('¤'));
                 _commonOperations.Verify();
             }
 

--- a/Test/VsVimSharedTest/VsCommandTargetTest.cs
+++ b/Test/VsVimSharedTest/VsCommandTargetTest.cs
@@ -364,6 +364,25 @@ namespace Vim.VisualStudio.UnitTest
             }
 
             /// <summary>
+            /// Must be able discard non-ASCII characters or they will end up
+            /// as input
+            /// </summary>
+            [WpfTheory]
+            [InlineData('¤')]
+            [InlineData('¨')]
+            [InlineData('£')]
+            [InlineData('§')]
+            [InlineData('´')]
+            public void CanProcessPrintableNonAscii(char c)
+            {
+                // Reported in issue #1793.
+                _commonOperations.Setup(x => x.Beep()).Verifiable();
+                _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
+                RunExec(KeyInputUtil.CharToKeyInput(c));
+                _commonOperations.Verify();
+            }
+
+            /// <summary>
             /// If there is buffered KeyInput values then the provided KeyInput shouldn't ever be 
             /// directly handled by the VsCommandTarget or the next IOleCommandTarget in the 
             /// chain.  It should be passed directly to the IVimBuffer if it can be handled else 


### PR DESCRIPTION
#### Issues

- Closes #2462

#### Discussion

Unfortunately, this had to change the model for how `IMode.CanProcess` works and when it returns true. The following discussion is very arcane, but I'll try to describe it in detail for future reference.

As background, if VsVim declines to handle a keyboard input at all of the various input points, the input falls back to Visual Studio which would then  assume the user was typing and insert the keyboard input into the buffer. There was even an issue (issue #1793) where non-ASCII characters got inserted into the buffer in normal mode instead of beeping.

As a result, many modes in VsVim typically report that they can process many, many more inputs than are actually valid inputs for that mode. This is because they desire to process them as an error rather than let Visual Studio handle the input erroneously.

This whole approach is predicated on the premise that a VsVim mode gets one chance to process they input. But the reality is that a mode may get **multiple** chances to process the raw keystrokes typed by the user. If we decline to handle a key combination during the `KeyDown` event, that key combination **may or may not** have an alternate interpretation that appears later during the `TextInput` event. Frankly, when we are in the `KeyDown` event, we have no idea whether a later `TextInput` event will be generated or what key input it will generate. There are control keys, dead keys, magic unicode keystroke sequences, etc. that are entirely outside of our control.

The ASCII control character `0x27 / ESC` on the Czech keyboard is an example of this kind of key. During the `KeyDown` event, we encounter a composite key that does not map to any ASCII character: `Ctrl+ú`. This is a perfectly valid key input from vim's point of view. And from VsVim's for that matter. But, if we decline to handle the `KeyDown` event, we will later receive a `TextInput` event for an entirely different character, this time an ASCII one: `0x27 / ESC`. But on the US keyboard, the same thing will happen. On `KeyDown`, VsVim will see the `Ctrl+[` composite key input, and if declined, will result in `0x27 / ESC` during the `TextInput` event.

The US keyboard doesn't have any problem here because both of the key inputs are the same from vim's point of view. But on the Czech keyboard, the only way we will ever find out that the keyboard produces ASCII `0x27 / ESC` by pressing the control key down at the same time as the `ú` key, is by declining to process it during the `KeyDown` event.

The best way for VsVim to handle this is by only handling `<C-ú>` as a composite key input when the user has a mapping for that key. If there is no such mapping, and they couldn't be trying to enter text into the buffer, then we can decline to handle the composite key input because **processing it would result in an error**. More specifically, it would beep.

This means that a mode may get several opportunities to see the same keystrokes, each converted into different key inputs. Accepting one too early prevents us from see the later ones. But if we decline to handle the first one, and **there is no second one**, Visual Studio could end up inserting characters into the buffer in a non-input mode.

As a result, we now have a new `CanProcess` model:

- A mode should return `true` for `CanProcess` only if it is either a valid key or we are certain it cannot be interpreted as a different valid key
- In non-insert modes we must handle undesired insertable text **at the very last minute**, i.e. just before we would pass it on to Visual Studio

In the current Visual Studio / VsVim architecture, the point of no return for key processing is during `StandardCommandTarget.Exec`. If we return false, Visual Studio will process the key input itself. if we don't want it to do that, that's where we need to decide if we return true.