### PR TITLE
Host command selection management

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4712,12 +4712,6 @@ type IVimHost =
     /// Save the current document as a new file with the specified name
     abstract SaveTextAs: text: string -> filePath: string -> bool 
 
-    /// Should the selection be kept after running the given host command?  In general 
-    /// VsVim will clear the selection after a host command because that is the vim
-    /// behavior.  Certain host commands exist to set selection though and clearing that
-    /// isn't desirable
-    abstract ShouldKeepSelectionAfterHostCommand: command: string -> argument: string -> bool 
-
     /// Called by Vim when it encounters a new ITextView and needs to know if it should 
     /// create an IVimBuffer for it
     abstract ShouldCreateVimBuffer: textView: ITextView -> bool

--- a/Src/VimCore/Interpreter_Expression.fs
+++ b/Src/VimCore/Interpreter_Expression.fs
@@ -587,7 +587,7 @@ and [<RequireQualifiedAccess>] LineCommand =
     | History
 
     /// Run a host command.  The first string is the command and the second string is the argument
-    | HostCommand of Command: string * Argument: string
+    | HostCommand of HasBang: bool * Command: string * Argument: string
 
     /// Process the 'split' command.  The values range as follows
     ///  - Height of the window if specified.  Expressed as a range.  The actual documentation

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1926,8 +1926,10 @@ type VimInterpreter
         let msg = sprintf "VsVim Version %s" VimConstants.VersionNumber
         _statusUtil.OnStatus msg
 
-    member x.RunHostCommand command argument =
+    member x.RunHostCommand hasBang command argument =
         _vimHost.RunHostCommand _textView command argument
+        if hasBang then
+            _textView.Selection.Clear()
 
     member x.RunWrite lineRange hasBang fileOptionList filePath =
         x.RunWithLineRangeOrDefault lineRange DefaultLineRange.EntireBuffer (fun lineRange ->
@@ -2035,7 +2037,7 @@ type VimInterpreter
         | LineCommand.GoToNextTab count -> x.RunGoToNextTab count
         | LineCommand.GoToPreviousTab count -> x.RunGoToPreviousTab count
         | LineCommand.HorizontalSplit (lineRange, fileOptions, commandOptions) -> x.RunSplit _vimHost.SplitViewHorizontally fileOptions commandOptions
-        | LineCommand.HostCommand (command, argument) -> x.RunHostCommand command argument
+        | LineCommand.HostCommand (hasBang, command, argument) -> x.RunHostCommand hasBang command argument
         | LineCommand.Join (lineRange, joinKind) -> x.RunJoin lineRange joinKind
         | LineCommand.JumpToLastLine lineRange -> x.RunJumpToLastLine lineRange
         | LineCommand.Let (name, value) -> x.RunLet name value

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1928,8 +1928,17 @@ type VimInterpreter
 
     member x.RunHostCommand hasBang command argument =
         _vimHost.RunHostCommand _textView command argument
-        if hasBang then
+        if hasBang && not _textView.Selection.IsEmpty then
+
+            // When clearing the selection after a host command, move the caret
+            // to the start of the selection because the selected text usually
+            // represents a "thing" (such as an identifier or group of text
+            // lines). The caret resting on the start of that thing better
+            // mimics the selection concept than putting the caret at the end
+            // of the thing.
+            let start = _textView.Selection.Start
             _textView.Selection.Clear()
+            TextViewUtil.MoveCaretToVirtualPoint _textView start
 
     member x.RunWrite lineRange hasBang fileOptionList filePath =
         x.RunWithLineRangeOrDefault lineRange DefaultLineRange.EntireBuffer (fun lineRange ->

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1853,6 +1853,7 @@ type Parser
     /// name can use letters, numbers and a period.  The rest of the line after will be taken
     /// as the argument
     member x.ParseHostCommand() = 
+        let hasBang = x.ParseBang()
         x.SkipBlanks()
         let command = x.ParseWhile (fun token -> 
             match token.TokenKind with 
@@ -1866,7 +1867,7 @@ type Parser
         | Some command ->
             x.SkipBlanks()
             let argument = x.ParseRestOfLine()
-            LineCommand.HostCommand (command, argument)
+            LineCommand.HostCommand (hasBang, command, argument)
 
     member x.ParseWrite lineRange = 
         let hasBang = x.ParseBang()

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -50,8 +50,11 @@ type internal CommandMode
                 command
 
         let lineCommand = _parser.ParseLineCommand command 
+
+        // We clear the selection for all line commands except a host command,
+        // which manages any selection clearing itself.
         match lineCommand with
-        | LineCommand.HostCommand (hasBang, command, argument) -> _keepSelection <- not hasBang
+        | LineCommand.HostCommand _ -> _keepSelection <- true
         | _ -> ()
 
         let vimInterpreter = _buffer.Vim.GetVimInterpreter _buffer

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -51,7 +51,7 @@ type internal CommandMode
 
         let lineCommand = _parser.ParseLineCommand command 
         match lineCommand with
-        | LineCommand.HostCommand (command, argument) -> _keepSelection <- _vimHost.ShouldKeepSelectionAfterHostCommand command argument
+        | LineCommand.HostCommand (hasBang, command, argument) -> _keepSelection <- not hasBang
         | _ -> ()
 
         let vimInterpreter = _buffer.Vim.GetVimInterpreter _buffer

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -399,11 +399,6 @@ namespace Vim.UnitTest.Mock
             get { return TabCount; }
         }
 
-        bool IVimHost.ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return false;
-        }
-
         bool IVimHost.UseDefaultCaret
         {
             get { return UseDefaultCaret; }

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -368,11 +368,6 @@ namespace Vim.UI.Wpf
             return vimRcPath.VimRcKind == VimRcKind.VsVimRc;
         }
 
-        public virtual bool ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return false;
-        }
-
         public virtual bool SaveTextAs(string text, string filePath)
         {
             try
@@ -758,11 +753,6 @@ namespace Vim.UI.Wpf
         bool IVimHost.SaveTextAs(string text, string filePath)
         {
             return SaveTextAs(text, filePath);
-        }
-
-        bool IVimHost.ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return ShouldKeepSelectionAfterHostCommand(command, argument);
         }
 
         bool IVimHost.ShouldCreateVimBuffer(ITextView textView)

--- a/Src/VsVimShared/ICommandDispatcher.cs
+++ b/Src/VsVimShared/ICommandDispatcher.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.Text.Editor;
+
+namespace Vim.VisualStudio
+{
+    /// <summary>
+    /// This interface facilitates the unit testing of operations that involve
+    /// command dispatching, like executing 'Edit.GoToDefinition' in the
+    /// appropriate way for a specified text view
+    /// </summary>
+    internal interface ICommandDispatcher
+    {
+        bool ExecuteCommand(ITextView textview, string command, string args, bool postCommand);
+    }
+}

--- a/Src/VsVimShared/IExtensionAdapter.cs
+++ b/Src/VsVimShared/IExtensionAdapter.cs
@@ -16,8 +16,6 @@ namespace Vim.VisualStudio
     {
         bool? IsUndoRedoExpected { get; }
 
-        bool? ShouldKeepSelectionAfterHostCommand(string command, string argument);
-
         bool? ShouldCreateVimBuffer(ITextView textView);
 
         bool? IsIncrementalSearchActive(ITextView textView);

--- a/Src/VsVimShared/Implementation/Misc/ExtensionAdapterBroker.cs
+++ b/Src/VsVimShared/Implementation/Misc/ExtensionAdapterBroker.cs
@@ -44,11 +44,6 @@ namespace Vim.VisualStudio.Implementation.Misc
             get { return RunOnAll(e => e.IsUndoRedoExpected); }
         }
 
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return RunOnAll(e => e.ShouldKeepSelectionAfterHostCommand(command, argument));
-        }
-
         bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView)
         {
             return RunOnAll(e => e.ShouldCreateVimBuffer(textView));

--- a/Src/VsVimShared/Implementation/Misc/PowerToolsUtil.cs
+++ b/Src/VsVimShared/Implementation/Misc/PowerToolsUtil.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Text.Editor;
 namespace Vim.VisualStudio.Implementation.Misc
 {
     [Export(typeof(IExtensionAdapter))]
-    internal sealed class PowerToolsUtil : IExtensionAdapter
+    internal sealed class PowerToolsUtil : VimExtensionAdapter
     {
         internal static readonly Guid QuickFindGuid = new Guid("4848f190-8e66-4af0-a898-454a568e8f65");
 
@@ -49,7 +49,7 @@ namespace Vim.VisualStudio.Implementation.Misc
             {
                 return (bool)isActiveInfo.GetValue(searchModel, null);
             }
-            catch (Exception)
+            catch
             {
                 return false;
             }
@@ -86,7 +86,7 @@ namespace Vim.VisualStudio.Implementation.Misc
                 var property = type.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
                 return property.GetValue(null, null);
             }
-            catch (Exception)
+            catch
             {
                 return null;
             }
@@ -100,33 +100,9 @@ namespace Vim.VisualStudio.Implementation.Misc
                 .FirstOrDefault();
         }
 
-        #region IExtensionAdapter
-
-        bool? IExtensionAdapter.IsUndoRedoExpected
-        {
-            get { return null; }
-        }
-
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.IsIncrementalSearchActive(ITextView textView)
+        protected override bool IsIncrementalSearchActive(ITextView textView)
         {
             return IsQuickFindActive();
         }
-
-        bool? IExtensionAdapter.UseDefaultCaret
-        {
-            get { return null; }
-        }
-
-        #endregion
     }
 }

--- a/Src/VsVimShared/Implementation/Misc/PowerToolsUtil.cs
+++ b/Src/VsVimShared/Implementation/Misc/PowerToolsUtil.cs
@@ -26,6 +26,10 @@ namespace Vim.VisualStudio.Implementation.Misc
             _isActivePropertyInfo = new Lazy<PropertyInfo>(GetIsActivePropertyInfo);
         }
 
+        // Detect PowerTools quick find as an incremental search.
+        protected override bool IsIncrementalSearchActive(ITextView textView) =>
+            IsQuickFindActive();
+
         private bool IsQuickFindActive()
         {
             if (!_isQuickFindInstalled)
@@ -98,11 +102,6 @@ namespace Vim.VisualStudio.Implementation.Misc
                 .GetAssemblies()
                 .Where(x => x.GetName().Name == "QuickFind")
                 .FirstOrDefault();
-        }
-
-        protected override bool IsIncrementalSearchActive(ITextView textView)
-        {
-            return IsQuickFindActive();
         }
     }
 }

--- a/Src/VsVimShared/Implementation/Misc/VisualStudioCommandDispatcher.cs
+++ b/Src/VsVimShared/Implementation/Misc/VisualStudioCommandDispatcher.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using EnvDTE;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Vim.VisualStudio.Implementation.Misc
+{
+    [Export(typeof(ICommandDispatcher))]
+    internal class VisualStudioCommandDispatcher : ICommandDispatcher
+    {
+        private readonly _DTE _dte;
+        private readonly IVsUIShell _uiShell;
+
+        [ImportingConstructor]
+        internal VisualStudioCommandDispatcher(SVsServiceProvider serviceProvider)
+        {
+            _dte = serviceProvider.GetService<SDTE, _DTE>();
+            _uiShell = serviceProvider.GetService<SVsUIShell, IVsUIShell>();
+        }
+
+        public bool ExecuteCommand(ITextView textView, string command, string args, bool postCommand)
+        {
+            // Many Visual Studio commands expect the focus to be in the editor
+            // when  running.  Switch focus there if an appropriate ITextView
+            // is available.
+            if (textView is IWpfTextView wpfTextView)
+            {
+                wpfTextView.VisualElement.Focus();
+            }
+
+            // Some commands like 'Edit.GoToDefinition' only work like they do
+            // when they are bound a key in Visual Studio like 'F12' when they
+            // are posted instead of executed synchronously. See issue #2535.
+            if (postCommand)
+            {
+                var dteCommand = _dte.Commands.Item(command, 0);
+                var guid = new Guid(dteCommand.Guid);
+                return _uiShell.PostExecCommand(ref guid, (uint)dteCommand.ID, 0, args) == VSConstants.S_OK;
+            }
+            else
+            {
+                _dte.ExecuteCommand(command, args);
+                return true;
+            }
+        }
+    }
+}

--- a/Src/VsVimShared/Implementation/PowerShellTools/PowerShellToolsExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/PowerShellTools/PowerShellToolsExtensionAdapter.cs
@@ -16,6 +16,10 @@ namespace Vim.VisualStudio.Implementation.PowerShellTools
             _powerShellToolsUtil = powerShellToolsUtil;
         }
 
+        // Suppress VsVim in the PowerShell interactive window.
+        protected override bool ShouldCreateVimBuffer(ITextView textView) =>
+            !IsInteractive(textView);
+
         private bool IsInteractive(ITextView textView)
         {
             if (!_powerShellToolsUtil.IsInstalled)
@@ -24,7 +28,5 @@ namespace Vim.VisualStudio.Implementation.PowerShellTools
             var contentTypeDisplayName = textView.TextDataModel.DocumentBuffer.ContentType.DisplayName;
             return contentTypeDisplayName == ReplContentTypeName;
         }
-
-        protected override bool ShouldCreateVimBuffer(ITextView textView) => IsInteractive(textView);
     }
 }

--- a/Src/VsVimShared/Implementation/PowerShellTools/PowerShellToolsExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/PowerShellTools/PowerShellToolsExtensionAdapter.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.Composition;
 namespace Vim.VisualStudio.Implementation.PowerShellTools
 {
     [Export(typeof(IExtensionAdapter))]
-    internal sealed class PowerShellToolsExtensionAdapter : IExtensionAdapter
+    internal sealed class PowerShellToolsExtensionAdapter : VimExtensionAdapter
     {
         //https://github.com/adamdriscoll/poshtools/blob/dev/ReplWindow/Repl/ReplConstants.cs
         private const string ReplContentTypeName = "PowerShellREPLCode";
@@ -16,45 +16,15 @@ namespace Vim.VisualStudio.Implementation.PowerShellTools
             _powerShellToolsUtil = powerShellToolsUtil;
         }
 
-        internal bool? ShouldCreateVimBuffer(ITextView textView)
+        private bool IsInteractive(ITextView textView)
         {
             if (!_powerShellToolsUtil.IsInstalled)
-                return null;
-
-            var contentTypeDisplayName = textView.TextDataModel.DocumentBuffer.ContentType.DisplayName;
-            if (contentTypeDisplayName == ReplContentTypeName)
                 return false;
 
-            return null;
+            var contentTypeDisplayName = textView.TextDataModel.DocumentBuffer.ContentType.DisplayName;
+            return contentTypeDisplayName == ReplContentTypeName;
         }
 
-        #region IExtensionAdapter
-
-        bool? IExtensionAdapter.IsUndoRedoExpected
-        {
-            get { return null; }
-        }
-
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView)
-        {
-            return ShouldCreateVimBuffer(textView);
-        }
-
-        bool? IExtensionAdapter.IsIncrementalSearchActive(ITextView textView)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.UseDefaultCaret
-        {
-            get { return null; }
-        }
-
-        #endregion
+        protected override bool ShouldCreateVimBuffer(ITextView textView) => IsInteractive(textView);
     }
 }

--- a/Src/VsVimShared/Implementation/ReSharper/ReSharperExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/ReSharper/ReSharperExtensionAdapter.cs
@@ -54,27 +54,7 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             return false;
         }
 
-        internal bool IsSelectionCommand(string command, string argument)
-        {
-            if (!_reSharperUtil.IsInstalled)
-            {
-                return false;
-            }
-
-            var comparer = StringComparer.OrdinalIgnoreCase;
-            if (comparer.Equals(command, "ReSharper.ReSharper_ExtendSelection") ||
-                comparer.Equals(command, "ReSharper.ReSharper_SurroundWith"))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         protected override bool ShouldCreateVimBuffer(ITextView textView) =>
             IsResharperWindow(textView);
-
-        protected override bool ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
-            IsSelectionCommand(command, argument);
     }
 }

--- a/Src/VsVimShared/Implementation/ReSharper/ReSharperExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/ReSharper/ReSharperExtensionAdapter.cs
@@ -14,7 +14,7 @@ using System.Diagnostics;
 namespace Vim.VisualStudio.Implementation.ReSharper
 {
     [Export(typeof(IExtensionAdapter))]
-    internal sealed class ReSharperExtensionAdapter : IExtensionAdapter
+    internal sealed class ReSharperExtensionAdapter : VimExtensionAdapter
     {
         internal const string FilePathPrefixRegexEditor = "RegularExpressionEditor";
         internal const string FilePathPrefixUnitTestSessionOutput = "StackTraceExplorerEditor";
@@ -29,17 +29,17 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             _textDocumentFactoryService = textDocumentFactoryService;
         }
 
-        internal bool? ShouldCreateVimBuffer(ITextView textView)
+        internal bool IsResharperWindow(ITextView textView)
         {
             if (!_reSharperUtil.IsInstalled)
             {
-                return null;
+                return false;
             }
 
             var textBuffer = textView.TextDataModel.DocumentBuffer;
             if (!_textDocumentFactoryService.TryGetTextDocument(textBuffer, out ITextDocument textDocument))
             {
-                return null;
+                return false;
             }
 
             // This is a bit of a heuristic.  It is technically possible for another component to create
@@ -48,24 +48,17 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             if (textDocument.FilePath.StartsWith(FilePathPrefixRegexEditor, StringComparison.OrdinalIgnoreCase) ||
                 textDocument.FilePath.StartsWith(FilePathPrefixUnitTestSessionOutput, StringComparison.OrdinalIgnoreCase))
             {
-                return false;
+                return true;
             }
 
-            return null;
+            return false;
         }
 
-        #region IExtensionAdapter
-
-        bool? IExtensionAdapter.IsUndoRedoExpected
-        {
-            get { return null; }
-        }
-
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument)
+        internal bool IsSelectionCommand(string command, string argument)
         {
             if (!_reSharperUtil.IsInstalled)
             {
-                return null;
+                return false;
             }
 
             var comparer = StringComparer.OrdinalIgnoreCase;
@@ -75,24 +68,13 @@ namespace Vim.VisualStudio.Implementation.ReSharper
                 return true;
             }
 
-            return null;
+            return false;
         }
 
-        bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView)
-        {
-            return ShouldCreateVimBuffer(textView);
-        }
+        protected override bool ShouldCreateVimBuffer(ITextView textView) =>
+            IsResharperWindow(textView);
 
-        bool? IExtensionAdapter.IsIncrementalSearchActive(ITextView textView)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.UseDefaultCaret
-        {
-            get { return null; }
-        }
-
-        #endregion
+        protected override bool ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
+            IsSelectionCommand(command, argument);
     }
 }

--- a/Src/VsVimShared/Implementation/ReSharper/ReSharperExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/ReSharper/ReSharperExtensionAdapter.cs
@@ -29,6 +29,10 @@ namespace Vim.VisualStudio.Implementation.ReSharper
             _textDocumentFactoryService = textDocumentFactoryService;
         }
 
+        // Suppress VsVim in the Resharper window.
+        protected override bool ShouldCreateVimBuffer(ITextView textView) =>
+            !IsResharperWindow(textView);
+
         internal bool IsResharperWindow(ITextView textView)
         {
             if (!_reSharperUtil.IsInstalled)
@@ -53,8 +57,5 @@ namespace Vim.VisualStudio.Implementation.ReSharper
 
             return false;
         }
-
-        protected override bool ShouldCreateVimBuffer(ITextView textView) =>
-            IsResharperWindow(textView);
     }
 }

--- a/Src/VsVimShared/Implementation/Roslyn/RoslynListenerFactory.cs
+++ b/Src/VsVimShared/Implementation/Roslyn/RoslynListenerFactory.cs
@@ -15,7 +15,7 @@ namespace Vim.VisualStudio.Implementation.Roslyn
     [Export(typeof(IExtensionAdapter))]
     [ContentType(VimConstants.ContentType)]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
-    internal sealed class RoslynListenerFactory : IVimBufferCreationListener, IExtensionAdapter
+    internal sealed class RoslynListenerFactory : VimExtensionAdapter, IVimBufferCreationListener
     {
         private IRoslynRenameUtil _roslynRenameUtil;
         private bool _inRename;
@@ -44,10 +44,7 @@ namespace Vim.VisualStudio.Implementation.Roslyn
         /// rename.  Need to register this as expected so the undo implementation doesn't
         /// raise any errors.
         /// </summary>
-        internal bool IsUndoRedoExpected
-        {
-            get { return _roslynRenameUtil != null && _roslynRenameUtil.IsRenameActive; }
-        }
+        internal bool IsActive => _roslynRenameUtil != null && _roslynRenameUtil.IsRenameActive;
 
         [ImportingConstructor]
         internal RoslynListenerFactory(SVsServiceProvider vsServiceProvider)
@@ -111,33 +108,6 @@ namespace Vim.VisualStudio.Implementation.Roslyn
             OnVimBufferCreated(vimBuffer);
         }
 
-        #region IExtensionAdapter
-
-        bool? IExtensionAdapter.IsUndoRedoExpected
-        {
-            get { return IsUndoRedoExpected; }
-        }
-
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.IsIncrementalSearchActive(ITextView textView)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.UseDefaultCaret
-        {
-            get { return null; }
-        }
-
-        #endregion
+        protected override bool IsUndoRedoExpected => IsActive;
     }
 }

--- a/Src/VsVimShared/Implementation/Roslyn/RoslynListenerFactory.cs
+++ b/Src/VsVimShared/Implementation/Roslyn/RoslynListenerFactory.cs
@@ -21,6 +21,10 @@ namespace Vim.VisualStudio.Implementation.Roslyn
         private bool _inRename;
         private List<IVimBuffer> _vimBufferList = new List<IVimBuffer>();
 
+        // Undo-redo is expected when the Roslyn Rename window is active.
+        protected override bool IsUndoRedoExpected =>
+            IsActive;
+
         internal IRoslynRenameUtil RenameUtil
         {
             get { return _roslynRenameUtil; }
@@ -107,7 +111,5 @@ namespace Vim.VisualStudio.Implementation.Roslyn
         {
             OnVimBufferCreated(vimBuffer);
         }
-
-        protected override bool IsUndoRedoExpected => IsActive;
     }
 }

--- a/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
@@ -17,7 +17,8 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
             _visualAssistUtil = visualAssistUtil;
         }
 
-        // Use default caret when VisualAssist is installed.
+        // Use default caret when VisualAssist is installed. Visual Assist
+        // Intellisense is predicated on the insertion cursor being visible.
         protected override bool UseDefaultCaret =>
             IsInstalled;
 

--- a/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
@@ -17,8 +17,10 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
             _visualAssistUtil = visualAssistUtil;
         }
 
-        private bool IsInstalled => _visualAssistUtil.IsInstalled;
+        // Use default caret when VisualAssist is installed.
+        protected override bool UseDefaultCaret =>
+            IsInstalled;
 
-        protected override bool UseDefaultCaret => IsInstalled;
+        private bool IsInstalled => _visualAssistUtil.IsInstalled;
     }
 }

--- a/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace Vim.VisualStudio.Implementation.VisualAssist
 {
     [Export(typeof(IExtensionAdapter))]
-    internal sealed class VisualAssistExtensionAdapter : IExtensionAdapter
+    internal sealed class VisualAssistExtensionAdapter : VimExtensionAdapter
     {
         private IVisualAssistUtil _visualAssistUtil;
 
@@ -17,18 +17,13 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
             _visualAssistUtil = visualAssistUtil;
         }
 
-        #region IExtensionAdapter
+        private bool IsInstalled => _visualAssistUtil.IsInstalled;
 
-        bool? IExtensionAdapter.IsUndoRedoExpected
-        {
-            get { return null; }
-        }
-
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument)
+        private bool IsSelectionCommand(string command, string argument)
         {
             if (!_visualAssistUtil.IsInstalled)
             {
-                return null;
+                return false;
             }
 
             var comparer = StringComparer.OrdinalIgnoreCase;
@@ -37,33 +32,12 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
                 return true;
             }
 
-            return null;
+            return false;
         }
 
-        bool? IExtensionAdapter.ShouldCreateVimBuffer(Microsoft.VisualStudio.Text.Editor.ITextView textView)
-        {
-            return null;
-        }
+        protected override bool ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
+            IsSelectionCommand(command, argument);
 
-        bool? IExtensionAdapter.IsIncrementalSearchActive(Microsoft.VisualStudio.Text.Editor.ITextView textView)
-        {
-            return null;
-        }
-
-        bool? IExtensionAdapter.UseDefaultCaret
-        {
-            get
-            {
-                if (!_visualAssistUtil.IsInstalled)
-                {
-                    return null;
-                }
-
-                // Visual Assist Intellisense is predicated on the insertion cursor being visible.
-                return true;
-            }
-        }
-
-        #endregion
+        protected override bool UseDefaultCaret => IsInstalled;
     }
 }

--- a/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/VisualAssist/VisualAssistExtensionAdapter.cs
@@ -19,25 +19,6 @@ namespace Vim.VisualStudio.Implementation.VisualAssist
 
         private bool IsInstalled => _visualAssistUtil.IsInstalled;
 
-        private bool IsSelectionCommand(string command, string argument)
-        {
-            if (!_visualAssistUtil.IsInstalled)
-            {
-                return false;
-            }
-
-            var comparer = StringComparer.OrdinalIgnoreCase;
-            if (comparer.Equals(command, "VAssistX.SmartSelectExtend"))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        protected override bool ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
-            IsSelectionCommand(command, argument);
-
         protected override bool UseDefaultCaret => IsInstalled;
     }
 }

--- a/Src/VsVimShared/VimExtensionAdapter.cs
+++ b/Src/VsVimShared/VimExtensionAdapter.cs
@@ -18,9 +18,6 @@ namespace Vim.VisualStudio
         protected virtual bool IsUndoRedoExpected =>
             false;
 
-        protected virtual bool ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
-            false;
-
         protected virtual bool ShouldCreateVimBuffer(ITextView textView) =>
             true;
 
@@ -41,9 +38,6 @@ namespace Vim.VisualStudio
 
         bool? IExtensionAdapter.IsUndoRedoExpected =>
             Unless(false, IsUndoRedoExpected);
-
-        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
-            Unless(false, ShouldKeepSelectionAfterHostCommand(command, argument));
 
         bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView) =>
             Unless(true, ShouldCreateVimBuffer(textView));

--- a/Src/VsVimShared/VimExtensionAdapter.cs
+++ b/Src/VsVimShared/VimExtensionAdapter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.Text.Editor;
+﻿using Microsoft.VisualStudio.Text.Editor;
 
 namespace Vim.VisualStudio
 {

--- a/Src/VsVimShared/VimExtensionAdapter.cs
+++ b/Src/VsVimShared/VimExtensionAdapter.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Vim.VisualStudio
+{
+    /// <summary>
+    /// This base class simplifies the implementation of extension adapters by
+    /// providing a default implementation for all extension points. If new
+    /// extension points are added, no existing extension adapters will need to
+    /// be changed unless they wish to participate in the new extension point.
+    /// </summary>
+    internal class VimExtensionAdapter : IExtensionAdapter
+    {
+        protected virtual bool IsUndoRedoExpected =>
+            false;
+
+        protected virtual bool ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
+            false;
+
+        protected virtual bool ShouldCreateVimBuffer(ITextView textView) =>
+            true;
+
+        protected virtual bool IsIncrementalSearchActive(ITextView textView) =>
+            false;
+
+        protected virtual bool UseDefaultCaret =>
+            false;
+
+        private bool? Unless(bool expected, bool value)
+        {
+            if (value != expected)
+            {
+                return value;
+            }
+            return null;
+        }
+
+        bool? IExtensionAdapter.IsUndoRedoExpected =>
+            Unless(false, IsUndoRedoExpected);
+
+        bool? IExtensionAdapter.ShouldKeepSelectionAfterHostCommand(string command, string argument) =>
+            Unless(false, ShouldKeepSelectionAfterHostCommand(command, argument));
+
+        bool? IExtensionAdapter.ShouldCreateVimBuffer(ITextView textView) =>
+            Unless(true, ShouldCreateVimBuffer(textView));
+
+        bool? IExtensionAdapter.IsIncrementalSearchActive(ITextView textView) =>
+            Unless(false, IsIncrementalSearchActive(textView));
+
+        bool? IExtensionAdapter.UseDefaultCaret =>
+            Unless(false, UseDefaultCaret);
+    }
+}

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -1148,24 +1148,6 @@ namespace Vim.VisualStudio
             }
         }
 
-        public override bool ShouldKeepSelectionAfterHostCommand(string command, string argument)
-        {
-            if (_extensionAdapterBroker.ShouldKeepSelectionAfterHostCommand(command, argument) ?? false)
-            {
-                return true;
-            }
-
-            var comparer = StringComparer.OrdinalIgnoreCase;
-            if (comparer.Equals(command, "Edit.SurroundWith"))
-            {
-                // Need to keep the selection here so the surround with command knows the selection
-                // to surround.
-                return true;
-            }
-
-            return base.ShouldKeepSelectionAfterHostCommand(command, argument);
-        }
-
         #region IVsSelectionEvents
 
         int IVsSelectionEvents.OnCmdUIContextChanged(uint dwCmdUICookie, int fActive)

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1518,6 +1518,7 @@ namespace Vim.UnitTest
                 RunCommandRaw(":vsc! Edit.Comment");
                 Assert.True(didRun);
                 Assert.True(_textView.Selection.IsEmpty);
+                Assert.Equal(_textView.GetPointInLine(0, 0), _textView.GetCaretPoint());
             }
 
             /// <summary>

--- a/Test/VimCoreTest/CommandModeIntegrationTest.cs
+++ b/Test/VimCoreTest/CommandModeIntegrationTest.cs
@@ -1484,6 +1484,42 @@ namespace Vim.UnitTest
                 Assert.True(didRun);
             }
 
+            [WpfFact]
+            public void KeepSelection()
+            {
+                Create("cat", "");
+                var didRun = false;
+                _vimHost.RunHostCommandFunc = (textView, commandName, argument) =>
+                    {
+                        didRun = true;
+                        Assert.Equal("Edit.Comment", commandName);
+                        Assert.Equal("", argument);
+                    };
+                _textView.Selection.Select(_textBuffer.GetSpan(0, 3));
+                Assert.False(_textView.Selection.IsEmpty);
+                RunCommandRaw(":vsc Edit.Comment");
+                Assert.True(didRun);
+                Assert.False(_textView.Selection.IsEmpty);
+            }
+
+            [WpfFact]
+            public void ClearSelection()
+            {
+                Create("cat", "");
+                var didRun = false;
+                _vimHost.RunHostCommandFunc = (textView, commandName, argument) =>
+                    {
+                        didRun = true;
+                        Assert.Equal("Edit.Comment", commandName);
+                        Assert.Equal("", argument);
+                    };
+                _textView.Selection.Select(_textBuffer.GetSpan(0, 3));
+                Assert.False(_textView.Selection.IsEmpty);
+                RunCommandRaw(":vsc! Edit.Comment");
+                Assert.True(didRun);
+                Assert.True(_textView.Selection.IsEmpty);
+            }
+
             /// <summary>
             /// It is legal for visual studio commands to have underscores in the name
             /// </summary>

--- a/Test/VsVimSharedTest/PowerShellToolsExtensionAdapterTest.cs
+++ b/Test/VsVimSharedTest/PowerShellToolsExtensionAdapterTest.cs
@@ -10,7 +10,7 @@ namespace Vim.VisualStudio.UnitTest
 {
     public abstract class PowerShellToolsExtensionAdapterTest
     {
-        private readonly PowerShellToolsExtensionAdapter _extensionAdapter;
+        private readonly IExtensionAdapter _extensionAdapter;
         private readonly Mock<IPowerShellToolsUtil> _powerShellToolsUtil;
 
         protected PowerShellToolsExtensionAdapterTest()

--- a/Test/VsVimSharedTest/ReSharperExtensionAdapterTest.cs
+++ b/Test/VsVimSharedTest/ReSharperExtensionAdapterTest.cs
@@ -16,7 +16,7 @@ namespace Vim.VisualStudio.UnitTest
 {
     public abstract class ReSharperExtensionAdapterTest 
     {
-        private readonly ReSharperExtensionAdapter _extensionAdapter;
+        private readonly IExtensionAdapter _extensionAdapter;
         private readonly Mock<IReSharperUtil> _resharperUtil;
         private readonly Mock<ITextDocumentFactoryService> _textDocumentFactoryService;
 

--- a/Test/VsVimSharedTest/VisualAssistExtensionAdapterTest.cs
+++ b/Test/VsVimSharedTest/VisualAssistExtensionAdapterTest.cs
@@ -24,22 +24,9 @@ namespace Vim.VisualStudio.UnitTest
         }
 
         [Fact]
-        public void CorrectCommands()
+        public void UseDefaultCaret()
         {
-            Assert.True(_adapter.ShouldKeepSelectionAfterHostCommand("VAssistX.SmartSelectExtend", ""));
-        }
-
-        [Fact]
-        public void IncorrectCommands()
-        {
-            Assert.Null(_adapter.ShouldKeepSelectionAfterHostCommand("VAssistX.SmartSelectExtendEx", ""));
-        }
-
-        [Fact]
-        public void CorrectCommandsNotInstalled()
-        {
-            _visualAssistUtil.SetupGet(x => x.IsInstalled).Returns(false);
-            Assert.Null(_adapter.ShouldKeepSelectionAfterHostCommand("VAssistX.SmartSelectExtend", ""));
+            Assert.True(_adapter.UseDefaultCaret);
         }
     }
 }

--- a/Test/VsVimSharedTest/VsVimHostTest.cs
+++ b/Test/VsVimSharedTest/VsVimHostTest.cs
@@ -31,7 +31,7 @@ namespace Vim.VisualStudio.UnitTest
         private Mock<IEditorOperationsFactoryService> _editorOperationsFactoryService;
         private Mock<IVimApplicationSettings> _vimApplicationSettings;
         private Mock<_DTE> _dte;
-        private Mock<IVsUIShell4> _uiVSShell;
+        private Mock<IVsUIShell> _uiVSShell;
         private Mock<IVsShell> _vsShell;
         private Mock<StatusBar> _statusBar;
         private Mock<IExtensionAdapterBroker> _extensionAdapterBroker;
@@ -46,7 +46,7 @@ namespace Vim.VisualStudio.UnitTest
             _editorAdaptersFactoryService = _factory.Create<IVsEditorAdaptersFactoryService>();
             _editorOperationsFactoryService = _factory.Create<IEditorOperationsFactoryService>();
             _statusBar = _factory.Create<StatusBar>();
-            _uiVSShell = _factory.Create<IVsUIShell4>();
+            _uiVSShell = _factory.Create<IVsUIShell>();
             _vsShell = _factory.Create<IVsShell>(MockBehavior.Loose);
             _dte = _factory.Create<_DTE>();
             _dte.SetupGet(x => x.StatusBar).Returns(_statusBar.Object);
@@ -197,6 +197,7 @@ namespace Vim.VisualStudio.UnitTest
                     Assert.True(_host.GoToDefinition());
                     _dte.Verify();
                 }
+
             }
         }
 

--- a/Test/VsVimSharedTest/VsVimHostTest.cs
+++ b/Test/VsVimSharedTest/VsVimHostTest.cs
@@ -35,6 +35,7 @@ namespace Vim.VisualStudio.UnitTest
         private Mock<IVsShell> _vsShell;
         private Mock<StatusBar> _statusBar;
         private Mock<IExtensionAdapterBroker> _extensionAdapterBroker;
+        private Mock<ICommandDispatcher> _commandDispatcher;
 
         private void Create()
         {
@@ -54,6 +55,7 @@ namespace Vim.VisualStudio.UnitTest
             _textManager.Setup(x => x.GetDocumentTextViews(DocumentLoad.RespectLazy)).Returns(new List<ITextView>());
             _vimApplicationSettings = _factory.Create<IVimApplicationSettings>(MockBehavior.Loose);
             _extensionAdapterBroker = _factory.Create<IExtensionAdapterBroker>(MockBehavior.Loose);
+            _commandDispatcher = _factory.Create<ICommandDispatcher>();
 
             var vsMonitorSelection = _factory.Create<IVsMonitorSelection>();
             uint selectionCookie = 42;
@@ -62,6 +64,7 @@ namespace Vim.VisualStudio.UnitTest
             var vsRunningDocumentTable = _factory.Create<IVsRunningDocumentTable>();
             uint runningDocumentTableCookie = 86;
             vsRunningDocumentTable.Setup(x => x.AdviseRunningDocTableEvents(It.IsAny<IVsRunningDocTableEvents3>(), out runningDocumentTableCookie)).Returns(VSConstants.S_OK);
+
 
             var sp = _factory.Create<SVsServiceProvider>();
             sp.Setup(x => x.GetService(typeof(_DTE))).Returns(_dte.Object);
@@ -86,6 +89,7 @@ namespace Vim.VisualStudio.UnitTest
                 ProtectedOperations,
                 _factory.Create<IMarkDisplayUtil>(MockBehavior.Loose).Object,
                 _factory.Create<IControlCharUtil>(MockBehavior.Loose).Object,
+                _commandDispatcher.Object,
                 sp.Object);
             _host = _hostRaw;
         }
@@ -109,8 +113,12 @@ namespace Vim.VisualStudio.UnitTest
                     Create();
                     var textView = CreateTextView("");
                     _textManager.SetupGet(x => x.ActiveTextViewOptional).Returns(textView);
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, string.Empty)).Throws(new Exception());
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(textView, VsVimHost.CommandNameGoToDefinition, string.Empty, false))
+                        .Throws(new Exception())
+                        .Verifiable();
                     Assert.False(_host.GoToDefinition());
+                    _commandDispatcher.Verify();
                 }
 
                 [WpfFact]
@@ -119,8 +127,48 @@ namespace Vim.VisualStudio.UnitTest
                     Create();
                     var textView = CreateTextView("");
                     _textManager.SetupGet(x => x.ActiveTextViewOptional).Returns(textView);
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, string.Empty));
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(textView, VsVimHost.CommandNameGoToDefinition, string.Empty, false))
+                        .Returns(true)
+                        .Verifiable();
                     Assert.True(_host.GoToDefinition());
+                    _commandDispatcher.Verify();
+                }
+
+                /// <summary>
+                /// Make sure that go to local declaration is translated into
+                /// go to defintion in a non-C++ language
+                /// </summary>
+                [WpfFact]
+                public void GoToLocalDeclaration()
+                {
+                    Create();
+                    var textView = CreateTextView("hello world");
+                    _textManager.SetupGet(x => x.ActiveTextViewOptional).Returns(textView);
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(textView, VsVimHost.CommandNameGoToDefinition, "hello", false))
+                        .Returns(true)
+                        .Verifiable();
+                    Assert.True(_host.GoToLocalDeclaration(textView, "hello"));
+                    _commandDispatcher.Verify();
+                }
+
+                /// <summary>
+                /// Make sure that go to global declaration is translated into
+                /// go to defintion in a non-C++ language
+                /// </summary>
+                [WpfFact]
+                public void GoToGlobalDeclaration()
+                {
+                    Create();
+                    var textView = CreateTextView("hello world");
+                    _textManager.SetupGet(x => x.ActiveTextViewOptional).Returns(textView);
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(textView, VsVimHost.CommandNameGoToDefinition, "hello", false))
+                        .Returns(true)
+                        .Verifiable();
+                    Assert.True(_host.GoToGlobalDeclaration(textView, "hello"));
+                    _commandDispatcher.Verify();
                 }
 
                 /// <summary>
@@ -134,8 +182,12 @@ namespace Vim.VisualStudio.UnitTest
                     var ct = GetOrCreateContentType("csharp", "code");
                     var textView = CreateTextView(ct, "hello world");
                     _textManager.SetupGet(x => x.ActiveTextViewOptional).Returns(textView);
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, ""));
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(textView, VsVimHost.CommandNameGoToDefinition, "", false))
+                        .Returns(true)
+                        .Verifiable();
                     Assert.True(_host.GoToDefinition());
+                    _commandDispatcher.Verify();
                 }
             }
 
@@ -153,51 +205,86 @@ namespace Vim.VisualStudio.UnitTest
                 }
 
                 /// <summary>
-                /// The C++ implementation of the goto definition command requires that the word which 
-                /// it should target be passed along as an argument to the command
+                /// The C++ implementation needs 'Edit.GoToDefinition' to
+                /// have a null argument and needs for it to be posted
                 /// </summary>
                 [WpfFact]
-                public void Simple()
+                public void GoToDefinition()
                 {
                     CreateWithText("hello world");
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, "hello")).Verifiable();
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(_textView, VsVimHost.CommandNameGoToDefinition, null, true))
+                        .Returns(true)
+                        .Verifiable();
                     Assert.True(_host.GoToDefinition());
-                    _dte.Verify();
-                }
-
-                [WpfFact]
-                public void MiddleOfIdentifier()
-                {
-                    CreateWithText("cat; dog");
-                    _textView.MoveCaretTo(1);
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, "cat")).Verifiable();
-                    Assert.True(_host.GoToDefinition());
-                    _dte.Verify();
-                }
-
-                [WpfFact]
-                public void MiddleOfLongIdentifier()
-                {
-                    CreateWithText("big_cat; dog");
-                    _textView.MoveCaretTo(1);
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, "big_cat")).Verifiable();
-                    Assert.True(_host.GoToDefinition());
-                    _dte.Verify();
+                    _commandDispatcher.Verify();
                 }
 
                 /// <summary>
-                /// The code should pass valid C++ identifiers to the GoToDefinition command.  It should not be 
-                /// using a full vim word (:help WORD) as it can include many non-legal C++ identifiers
+                /// The C++ implementation needs 'Edit.GoToDeclaration' to
+                /// have a null argument and needs for it to be posted
                 /// </summary>
                 [WpfFact]
-                public void Issue1122()
+                public void GoToLocalDeclaration()
                 {
-                    CreateWithText("cat; dog");
-                    _dte.Setup(x => x.ExecuteCommand(VsVimHost.CommandNameGoToDefinition, "cat")).Verifiable();
-                    Assert.True(_host.GoToDefinition());
-                    _dte.Verify();
+                    CreateWithText("hello world");
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(_textView, VsVimHost.CommandNameGoToDeclaration, null, true))
+                        .Returns(true)
+                        .Verifiable();
+                    Assert.True(_host.GoToLocalDeclaration(_textView, "hello"));
+                    _commandDispatcher.Verify();
                 }
 
+                /// <summary>
+                /// The C++ implementation needs 'Edit.GoToDeclaration' to
+                /// have a null argument and needs for it to be posted
+                /// </summary>
+                [WpfFact]
+                public void GoToGlobalDeclaration()
+                {
+                    CreateWithText("hello world");
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(_textView, VsVimHost.CommandNameGoToDeclaration, null, true))
+                        .Returns(true)
+                        .Verifiable();
+                    Assert.True(_host.GoToGlobalDeclaration(_textView, "hello"));
+                    _commandDispatcher.Verify();
+                }
+
+                /// <summary>
+                /// When go to definition is executed as a host command, it
+                /// should use the same dispatching logic as if go to
+                /// definition were called directly
+                /// </summary>
+                [WpfFact]
+                public void GoToDefinition_HostCommand()
+                {
+                    CreateWithText("hello world");
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(_textView, VsVimHost.CommandNameGoToDefinition, null, true))
+                        .Returns(true)
+                        .Verifiable();
+                    _host.RunHostCommand(_textView, VsVimHost.CommandNameGoToDefinition, "");
+                    _commandDispatcher.Verify();
+                }
+
+                /// <summary>
+                /// When go to declaration is executed as a host command, it
+                /// should use the same dispatching logic as if go to
+                /// local/global declaration were called directly
+                /// </summary>
+                [WpfFact]
+                public void GoToDeclaration_HostCommand()
+                {
+                    CreateWithText("hello world");
+                    _commandDispatcher
+                        .Setup(x => x.ExecuteCommand(_textView, VsVimHost.CommandNameGoToDeclaration, null, true))
+                        .Returns(true)
+                        .Verifiable();
+                    _host.RunHostCommand(_textView, VsVimHost.CommandNameGoToDeclaration, "");
+                    _commandDispatcher.Verify();
+                }
             }
         }
 


### PR DESCRIPTION
#### Issues

- Closes #2470
- Closes #2535

#### Discussion

##### Selection Management

This is an alternative approach to PR 2473 that addresses the issue in #2470, one that is designed to prevent the need for VsVim to maintain any record of which Visual Studio commands do or do not need the selection cleared. Instead, it adds a special "has bang" version of `:vsc! [command]` which means: execute the command and then clear the selection. Any `:vsc [command]` without the bang does not modify the selection.

Users who have any existing mappings for keys where the old selection clearing logic was chosen and where that behavior was desirable will need to add bang to their mappings. I don't know of any such commands offhand where this would be the case, but I imagine there might be some.

In any case, the user now has full control of the selection clearing logic in those few situations where it was necessary. Because vim does not support the `:vsc` command, how VsVim behaves when you use it cannot be incompatible with vim. And it is still true, in general, that, like vim, VsVim usually clears the selection after any colon-command, just not for `vsc` commands.

##### Go To Definition / Go To Declaration

This change also includes a revised approach to the long-standing problem of the `Edit.GoToDefinition` command when used with the C++ language service. As a reluctant but frequent C++ programmer, I am very excited about this change as it makes `<C-]>` work **exactly** like `F12` and `gd` work **exactly** like `Edit.GoToDeclaration`.

The solution for C++ is to use a different Visual Studio API for command execution so that we can post the command asynchronously instead of executing it directly. I don't know why this works but it does.