### PR TITLE
Map point supplied to 'ensure at point' to current snapshot

### DIFF
--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -2193,6 +2193,23 @@ type internal CommonOperations
                 | 2 -> _globalSettings.ImeSearch <- 0
                 | _ -> _globalSettings.ImeSearch <- 2
 
+    /// Map the specified point with negative tracking to the current snapshot
+    member x.MapPointNegativeToCurrentSnapshot (point: SnapshotPoint) =
+        x.MapPointToCurrentSnapshot point PointTrackingMode.Negative
+
+    /// Map the specified point with positive tracking to the current snapshot
+    member x.MapPointPositiveToCurrentSnapshot (point: SnapshotPoint) =
+        x.MapPointToCurrentSnapshot point PointTrackingMode.Positive
+
+    /// Map the specified point with the specified tracking to the current snapshot
+    member x.MapPointToCurrentSnapshot (point: SnapshotPoint) (pointTrackingMode: PointTrackingMode) =
+        let snapshot = _textBuffer.CurrentSnapshot
+        if point.Snapshot = snapshot then
+            point
+        else
+            TrackingPointUtil.GetPointInSnapshot point pointTrackingMode snapshot
+            |> OptionUtil.getOrDefault (SnapshotPoint(snapshot, min point.Position snapshot.Length))
+
     interface ICommonOperations with
         member x.VimBufferData = _vimBufferData
         member x.TextView = _textView 
@@ -2263,6 +2280,8 @@ type internal CommonOperations
         member x.SortLines range reverseOrder flags pattern = x.SortLines range reverseOrder flags pattern
         member x.Substitute pattern replace range flags = x.Substitute pattern replace range flags
         member x.ToggleLanguage isForInsert = x.ToggleLanguage isForInsert
+        member x.MapPointNegativeToCurrentSnapshot point = x.MapPointNegativeToCurrentSnapshot point
+        member x.MapPointPositiveToCurrentSnapshot point = x.MapPointPositiveToCurrentSnapshot point
         member x.Undo count = x.Undo count
 
 [<Export(typeof<ICommonOperationsFactory>)>]

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -2070,6 +2070,7 @@ type internal CommonOperations
 
     /// Ensure the given view properties are met at the given point
     member x.EnsureAtPoint point viewFlags = 
+        let point = x.MapPointNegativeToCurrentSnapshot point
         if Util.IsFlagSet viewFlags ViewFlags.TextExpanded then
             x.EnsurePointExpanded point
         if Util.IsFlagSet viewFlags ViewFlags.Visible then

--- a/Src/VimCore/InsertUtil.fs
+++ b/Src/VimCore/InsertUtil.fs
@@ -611,9 +611,8 @@ type internal InsertUtil
                     x.ApplyBlockInsert text atEndOfLine startLineNumber blockSpan.BeforeSpaces (blockSpan.Height - 1)
 
                     // insertion point which is the start of the BlockSpan.
-                    match TrackingPointUtil.GetPointInSnapshot blockSpan.Start.StartPoint PointTrackingMode.Negative x.CurrentSnapshot with
-                    | None -> ()
-                    | Some point -> TextViewUtil.MoveCaretToPoint _textView point
+                    _operations.MapPointNegativeToCurrentSnapshot blockSpan.Start.StartPoint
+                    |> TextViewUtil.MoveCaretToPoint _textView
                     
                     Some text)
             | _ -> None

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -716,10 +716,7 @@ type VimInterpreter
 
                 // Translate the insertion point to the current snapshot and
                 // move to it.
-                match TrackingPointUtil.GetPointInSnapshot destPoint PointTrackingMode.Negative newSnapshot with
-                | Some destPoint -> destPoint.Position
-                | None -> destPoint.Position
-                |> (fun position -> new SnapshotPoint(_textBuffer.CurrentSnapshot, position))
+                _commonOperations.MapPointNegativeToCurrentSnapshot destPoint
                 |> (fun point -> _commonOperations.MoveCaretToPoint point ViewFlags.VirtualEdit)
                 _commonOperations.RestoreSpacesToCaret spaces true)
 

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -541,6 +541,12 @@ type ICommonOperations =
     /// Toggle the use of typing language characters
     abstract ToggleLanguage: isForInsert: bool -> unit
 
+    /// Map the specified point with negative tracking to the current snapshot
+    abstract MapPointNegativeToCurrentSnapshot: point: SnapshotPoint -> SnapshotPoint
+
+    /// Map the specified point with positive tracking to the current snapshot
+    abstract MapPointPositiveToCurrentSnapshot: point: SnapshotPoint -> SnapshotPoint
+
     /// Undo the buffer changes "count" times
     abstract Undo: count: int -> unit
 

--- a/Src/VimCore/Modes_Visual_SelectMode.fs
+++ b/Src/VimCore/Modes_Visual_SelectMode.fs
@@ -150,10 +150,9 @@ type internal SelectMode
                 // add one here (or even the length of the insert text).  The insert occurred at
                 // the exact point we are tracking and we chose PointTrackingMode.Positive so this
                 // will push the point past the insert
-                let snapshot = TextEditUtil.ApplyAndGetLatest edit
-                match TrackingPointUtil.GetPointInSnapshot span.End PointTrackingMode.Positive snapshot with
-                | None -> ()
-                | Some point -> TextViewUtil.MoveCaretToPoint _textView point
+                edit.Apply() |> ignore
+                _commonOperations.MapPointPositiveToCurrentSnapshot span.End
+                |> TextViewUtil.MoveCaretToPoint _textView
 
         // During undo we don't want the currently selected text to be reselected as that
         // would put the editor back into select mode.  Clear the selection now so that


### PR DESCRIPTION
#### Issues

- Closes #2538

#### Discussion

This also adds common infrastructure to map points to the current snapshot and uses it systematically to simplify and regularize all the places that are currently performing that function by hand.