### PR TITLE
Cautiously get text view line containing buffer position

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -3311,18 +3311,19 @@ type internal CommandUtil
                 lastLine
             else
 
-                // The last line is only partially visible. This could be either because
-                // the view is scrolled so that the bottom of the text row is clipped,
-                // or because line wrapping is in effect and there are off-screen
-                // wrapped text view lines. In either case, try to move to the text
-                // view line corresponding to the previous snapshot line.
+                // The last line is only partially visible. This could be
+                // either because the view is scrolled so that the bottom of
+                // the text row is clipped, or because line wrapping is in
+                // effect and there are off-screen wrapped text view lines. In
+                // either case, try to move to the text view line corresponding
+                // to the previous snapshot line.
                 let partialLine = SnapshotPointUtil.GetContainingLine lastLine.Start
                 let previousLineNumber = partialLine.LineNumber - 1
                 let previousLine = SnapshotUtil.GetLineOrFirst _textView.TextSnapshot previousLineNumber
-                let textViewLine = textViewLines.GetTextViewLineContainingBufferPosition previousLine.Start
-                if textViewLine.VisibilityState = Formatting.VisibilityState.FullyVisible then
+                match TextViewUtil.GetTextViewLineContainingPoint _textView previousLine.Start with
+                | Some textViewLine when textViewLine.VisibilityState = Formatting.VisibilityState.FullyVisible ->
                     textViewLine
-                else
+                | _ ->
                     lastLine
 
         let spacesToCaret = _commonOperations.GetSpacesToCaret()

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -3146,16 +3146,14 @@ module TextViewUtil =
                 let option = Editor.EnsureSpanVisibleOptions.AlwaysCenter
                 textView.ViewScroller.EnsureSpanVisible(span, option) |> ignore
 
+        // We need to scroll if the caret is offscreen.
         match GetTextViewLineContainingPoint textView point with
-        | Some textViewLine ->
-            let onScreen = textViewLine.VisibilityState = Formatting.VisibilityState.FullyVisible
-            if not onScreen then
-
-                // The line the point is on is off-screen.
-                match GetTextViewLines textView with
-                | Some textViewLines -> doScrollToPoint textViewLines
-                | _ -> ()
-        | None -> ()
+        | Some textViewLine when textViewLine.VisibilityState = Formatting.VisibilityState.FullyVisible ->
+            ()
+        | _ ->
+            match GetTextViewLines textView with
+            | Some textViewLines -> doScrollToPoint textViewLines
+            | _ -> ()
 
     /// Clear out the selection
     let ClearSelection (textView: ITextView) =

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -3010,14 +3010,21 @@ module TextViewUtil =
             // Protect against GetTextViewLineContainingBufferPosition
             // returning null.
             match textViewLines.GetTextViewLineContainingBufferPosition point with
-            | textViewLine when textViewLine <> null ->
-                textViewLines.GetIndexOfTextLine textViewLine
-                |> (fun index -> index + offset)
-                |> max 0
-                |> min (textViewLines.Count - 1)
-                |> (fun index -> textViewLines.[index])
-                |> Some
+            | textViewLine when textViewLine <> null && textViewLine.IsValid ->
+                if offset = 0 then
+                    Some textViewLine
+                else
 
+                    // Validate offset.
+                    let index = textViewLines.GetIndexOfTextLine textViewLine
+                    if index + offset >= 0 && index + offset < textViewLines.Count then
+                        let textViewLine = textViewLines.[index + offset]
+                        if textViewLine.IsValid then
+                            Some textViewLine
+                        else
+                            None
+                    else
+                        None
             | _ -> None
         | None -> None
 

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -462,6 +462,10 @@ namespace Vim.UI.Wpf
         {
             const double roundOff = 0.01;
             var textViewLine = textView.GetTextViewLineContainingBufferPosition(point);
+            if (textViewLine == null)
+            {
+                return;
+            }
 
             switch (textViewLine.VisibilityState)
             {
@@ -515,6 +519,10 @@ namespace Vim.UI.Wpf
         private void EnsureLinePointVisible(ITextView textView, SnapshotPoint point)
         {
             var textViewLine = textView.GetTextViewLineContainingBufferPosition(point);
+            if (textViewLine == null)
+            {
+                return;
+            }
 
             const double horizontalPadding = 2.0;
             const double scrollbarPadding = 200.0;

--- a/Test/VimCoreTest/TextViewUtilTest.cs
+++ b/Test/VimCoreTest/TextViewUtilTest.cs
@@ -29,9 +29,17 @@ namespace Vim.UnitTest
                 caret: caret.Object,
                 factory: factory);
 
+            // Make sure we do all the caution checks necessary to ensure the
+            // text view line is valid.
+            textView.SetupGet(x => x.IsClosed).Returns(false).Verifiable();
+            textView.SetupGet(x => x.InLayout).Returns(false).Verifiable();
+            var lines = factory.Create<ITextViewLineCollection>();
+            textView.Setup(x => x.TextViewLines).Returns(lines.Object).Verifiable();
             var line = factory.Create<ITextViewLine>();
+            lines.SetupGet(x => x.IsValid).Returns(true).Verifiable();
+            lines.Setup(x => x.GetTextViewLineContainingBufferPosition(It.IsAny<SnapshotPoint>())).Returns(line.Object).Verifiable();
+            line.SetupGet(x => x.IsValid).Returns(true).Verifiable();
             line.SetupGet(x => x.VisibilityState).Returns(VisibilityState.FullyVisible).Verifiable();
-            textView.Setup(x => x.GetTextViewLineContainingBufferPosition(It.IsAny<SnapshotPoint>())).Returns(line.Object).Verifiable();
 
             var point = new VirtualSnapshotPoint(buffer.GetLine(0), 2);
             caret.Setup(x => x.MoveTo(point)).Returns(new CaretPosition()).Verifiable();


### PR DESCRIPTION
#### Issues

- Closes #2161 

#### Discussion

It turns out that `GetTextViewLineContainingBufferPosition` can return `null`, and VsVim uses it in many different places, and so the changes are larger than you might think would be necessary. The solution, as with our other problems with text view exceptions, is to provide an API in `TextViewUtil`, make that API cautious and robust, and then systematically use it in preference to calling the editor API function directly.