### PR TITLE
Only commands typed interactively enter the command history

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4524,7 +4524,7 @@ type internal IHistoryClient<'TData, 'TResult> =
 
     /// Called when the command is completed.  The last valid TData and command
     /// string will be provided
-    abstract Completed: data: 'TData -> command: string -> 'TResult
+    abstract Completed: data: 'TData -> command: string -> wasMapped: bool -> 'TResult
 
     /// Called when the command is cancelled.  The last valid TData value will
     /// be provided

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -1472,8 +1472,10 @@ module KeyInputSetUtil =
 [<NoEquality>]
 type KeyMappingResult =
 
-    /// The values were mapped completely and require no further mapping. This 
-    /// could be a result of a no-op mapping though
+    /// The values were not mapped
+    | Unmapped of KeyInputSet: KeyInputSet
+
+    /// The values were mapped completely and require no further mapping
     | Mapped of KeyInputSet: KeyInputSet
 
     /// The values were partially mapped but further mapping is required once the
@@ -1494,6 +1496,7 @@ type KeyMappingResult =
     /// was possible 
     member x.KeyInputSet = 
         match x with
+        | Unmapped keyInputSet -> keyInputSet
         | Mapped keyInputSet -> keyInputSet
         | PartiallyMapped (keyInputSet, _) -> keyInputSet
         | Recursive -> KeyInputSet.Empty

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3650,10 +3650,10 @@ type BindDataStorage<'T> =
 /// This is the result of attemping to bind a series of KeyInputData values
 /// into a Motion Command, etc ...
 [<RequireQualifiedAccess>]
-type MappedBindResult<'T> = 
+type MappedBindResult<'T> =
 
     /// Successfully bound to a value
-    | Complete of Result: 'T 
+    | Complete of Result: 'T
 
     /// More input is needed to complete the binding operation
     | NeedMoreInput of MappedBindData: MappedBindData<'T>
@@ -3670,14 +3670,14 @@ type MappedBindResult<'T> =
     /// forwarding from one to the other once the value is completed
     member x.Map (mapFunc: 'T -> MappedBindResult<'U>): MappedBindResult<'U> =
         match x with
-        | Complete value -> mapFunc value 
+        | Complete value -> mapFunc value
         | NeedMoreInput (bindData: MappedBindData<'T>) -> NeedMoreInput (bindData.Map mapFunc)
         | Error -> Error
         | Cancelled -> Cancelled
 
     /// Used to convert a MappedBindResult<'T>.Completed to
     /// MappedBindResult<'U>.Completed through a conversion function
-    member x.Convert (convertFunc: 'T -> 'U): MappedBindResult<'U> = 
+    member x.Convert (convertFunc: 'T -> 'U): MappedBindResult<'U> =
         x.Map (fun value -> convertFunc value |> MappedBindResult.Complete)
 
     /// Convert this MappedBindResult<'T> to a BindResult<'T>
@@ -3692,7 +3692,7 @@ and MappedBindData<'T> = {
 
     /// The optional KeyRemapMode which should be used when binding the next
     /// KeyInput in the sequence
-    KeyRemapMode: KeyRemapMode 
+    KeyRemapMode: KeyRemapMode
 
     /// Function to call to get the MappedBindResult for this data
     MappedBindFunction: KeyInputData -> MappedBindResult<'T>
@@ -3703,9 +3703,9 @@ and MappedBindData<'T> = {
 
     /// Very similar to the Convert function.  This will instead map a
     /// MappedBindData<'T>.Completed to a MappedBindData<'U> of any form
-    member x.Map<'U> (mapFunc: 'T -> MappedBindResult<'U>): MappedBindData<'U> = 
+    member x.Map<'U> (mapFunc: 'T -> MappedBindResult<'U>): MappedBindData<'U> =
         let originalBindFunc = x.MappedBindFunction
-        let bindFunc keyInput = 
+        let bindFunc keyInput =
             match originalBindFunc keyInput with
             | MappedBindResult.Cancelled -> MappedBindResult.Cancelled
             | MappedBindResult.Complete value -> mapFunc value
@@ -3717,7 +3717,7 @@ and MappedBindData<'T> = {
     /// binding to succeed so we can create a projected value.  This function
     /// will allow us to translate a MappedBindResult<'T>.Completed ->
     /// MappedBindResult<'U>.Completed
-    member x.Convert (convertFunc: 'T -> 'U): MappedBindData<'U> = 
+    member x.Convert (convertFunc: 'T -> 'U): MappedBindData<'U> =
         x.Map (fun value -> convertFunc value |> MappedBindResult.Complete)
 
     /// Convert this MappedBindData<'T> to a BindData<'T> (note that as a
@@ -3748,7 +3748,7 @@ type MappedBindDataStorage<'T> =
     with
 
     /// Creates the MappedBindData
-    member x.CreateBindData () = 
+    member x.CreateMappedBindData () = 
         match x with
         | Simple bindData -> bindData
         | Complex func -> func()

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -5369,7 +5369,7 @@ and IMode =
     abstract CanProcess: KeyInput -> bool
 
     /// Process the given KeyInput
-    abstract Process: KeyInput -> ProcessResult
+    abstract Process: KeyInputData -> ProcessResult
 
     /// Called when the mode is entered
     abstract OnEnter: ModeArgument -> unit

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -3647,6 +3647,99 @@ type BindDataStorage<'T> =
         | Simple bindData -> Simple (bindData.Convert mapFunc)
         | Complex func -> Complex (fun () -> func().Convert mapFunc)
 
+/// This is the result of attemping to bind a series of KeyInput values into a Motion
+/// Command, etc ... 
+[<RequireQualifiedAccess>]
+type MappedBindResult<'T> = 
+
+    /// Successfully bound to a value
+    | Complete of Result: 'T 
+
+    /// More input is needed to complete the binding operation
+    | NeedMoreInput of MappedBindData: MappedBindData<'T>
+
+    /// There was an error completing the binding operation
+    | Error
+
+    /// Motion was cancelled via user input
+    | Cancelled
+
+    with
+
+    /// Used to compose to MappedBindResult<'T> functions together by forwarding from
+    /// one to the other once the value is completed
+    member x.Map (mapFunc: 'T -> MappedBindResult<'U>): MappedBindResult<'U> =
+        match x with
+        | Complete value -> mapFunc value 
+        | NeedMoreInput (bindData: MappedBindData<'T>) -> NeedMoreInput (bindData.Map mapFunc)
+        | Error -> Error
+        | Cancelled -> Cancelled
+
+    /// Used to convert a MappedBindResult<'T>.Completed to MappedBindResult<'U>.Completed through a conversion
+    /// function
+    member x.Convert (convertFunc: 'T -> 'U): MappedBindResult<'U> = 
+        x.Map (fun value -> convertFunc value |> MappedBindResult.Complete)
+
+and MappedBindData<'T> = {
+
+    /// The optional KeyRemapMode which should be used when binding
+    /// the next KeyInput in the sequence
+    KeyRemapMode: KeyRemapMode 
+
+    /// Function to call to get the MappedBindResult for this data
+    MappedBindFunction: KeyInputData -> MappedBindResult<'T>
+
+} with
+
+    member x.CreateBindResult() = MappedBindResult.NeedMoreInput x
+
+    /// Very similar to the Convert function.  This will instead map a MappedBindData<'T>.Completed
+    /// to a MappedBindData<'U> of any form 
+    member x.Map<'U> (mapFunc: 'T -> MappedBindResult<'U>): MappedBindData<'U> = 
+        let originalBindFunc = x.MappedBindFunction
+        let bindFunc keyInput = 
+            match originalBindFunc keyInput with
+            | MappedBindResult.Cancelled -> MappedBindResult.Cancelled
+            | MappedBindResult.Complete value -> mapFunc value
+            | MappedBindResult.Error -> MappedBindResult.Error
+            | MappedBindResult.NeedMoreInput bindData -> MappedBindResult.NeedMoreInput (bindData.Map mapFunc)
+        { KeyRemapMode = x.KeyRemapMode; MappedBindFunction = bindFunc }
+
+    /// Often types bindings need to compose together because we need an inner binding
+    /// to succeed so we can create a projected value.  This function will allow us
+    /// to translate a MappedBindResult<'T>.Completed -> MappedBindResult<'U>.Completed
+    member x.Convert (convertFunc: 'T -> 'U): MappedBindData<'U> = 
+        x.Map (fun value -> convertFunc value |> MappedBindResult.Complete)
+
+/// Several types of MappedBindData<'T> need to take an action when a binding begins against
+/// themselves. This action needs to occur before the first KeyInput value is processed
+/// and hence they need a jump start. The most notable is IncrementalSearch which 
+/// needs to enter 'Search' mode before processing KeyInput values so the cursor can
+/// be updated
+[<RequireQualifiedAccess>]
+type MappedBindDataStorage<'T> =
+
+    /// Simple MappedBindData<'T> which doesn't require activation
+    | Simple of MappedBindData: MappedBindData<'T> 
+
+    /// Complex MappedBindData<'T> which does require activation
+    | Complex of CreateBindDataFunc: (unit -> MappedBindData<'T>)
+
+    with
+
+    /// Creates the MappedBindData
+    member x.CreateBindData () = 
+        match x with
+        | Simple bindData -> bindData
+        | Complex func -> func()
+
+    /// Convert from a MappedBindDataStorage<'T> -> MappedBindDataStorage<'U>.  The 'mapFunc' value
+    /// will run on the final 'T' data if it eventually is completed
+    member x.Convert mapFunc = 
+        match x with
+        | Simple bindData -> Simple (bindData.Convert mapFunc)
+        | Complex func -> Complex (fun () -> func().Convert mapFunc)
+
 /// Representation of binding of Command's to KeyInputSet values and flags which correspond
 /// to the execution of the command
 [<DebuggerDisplay("{ToString(),nq}")>]
@@ -4440,7 +4533,7 @@ type internal IHistorySession<'TData, 'TResult> =
 
     /// Create an BindDataStorage for this session which will process relevant KeyInput values
     /// as manipulating the current history
-    abstract CreateBindDataStorage: unit -> BindDataStorage<'TResult>
+    abstract CreateBindDataStorage: unit -> MappedBindDataStorage<'TResult>
 
 /// Represents shared state which is available to all IVimBuffer instances.
 type IVimData = 

--- a/Src/VimCore/DisabledMode.fs
+++ b/Src/VimCore/DisabledMode.fs
@@ -14,7 +14,8 @@ type internal DisabledMode(_vimBufferData: IVimBufferData) =
         else
             sprintf "Vim Disabled. Type %s+%s to re-enable" (keyInput.Key.ToString()) (keyInput.KeyModifiers.ToString())
 
-    member x.Process keyInput = 
+    member x.Process (keyInputData: KeyInputData) = 
+        let keyInput = keyInputData.KeyInput
         if keyInput = _globalSettings.DisableAllCommand then
             ProcessResult.OfModeKind ModeKind.Normal
         else
@@ -26,7 +27,7 @@ type internal DisabledMode(_vimBufferData: IVimBufferData) =
         member x.ModeKind = ModeKind.Disabled        
         member x.CommandNames = Seq.singleton (KeyInputSet(_globalSettings.DisableAllCommand))
         member x.CanProcess keyInput = keyInput = _globalSettings.DisableAllCommand
-        member x.Process keyInput = x.Process keyInput
+        member x.Process keyInputData = x.Process keyInputData
         member x.OnEnter _  = ()
         member x.OnLeave() = ()
         member x.OnClose() = ()

--- a/Src/VimCore/DisabledMode.fs
+++ b/Src/VimCore/DisabledMode.fs
@@ -15,8 +15,7 @@ type internal DisabledMode(_vimBufferData: IVimBufferData) =
             sprintf "Vim Disabled. Type %s+%s to re-enable" (keyInput.Key.ToString()) (keyInput.KeyModifiers.ToString())
 
     member x.Process (keyInputData: KeyInputData) = 
-        let keyInput = keyInputData.KeyInput
-        if keyInput = _globalSettings.DisableAllCommand then
+        if keyInputData.KeyInput = _globalSettings.DisableAllCommand then
             ProcessResult.OfModeKind ModeKind.Normal
         else
             ProcessResult.NotHandled

--- a/Src/VimCore/ExternalEdit.fs
+++ b/Src/VimCore/ExternalEdit.fs
@@ -9,8 +9,9 @@ type internal ExternalEditMode(_vimBufferData: IVimBufferData) =
         member x.ModeKind = ModeKind.ExternalEdit
         member x.CommandNames = Seq.empty
         member x.CanProcess keyInput = keyInput = KeyInputUtil.EscapeKey
-        member x.Process keyInput = 
-            if keyInput = KeyInputUtil.EscapeKey then
+        member x.CanProcess ki = ki = KeyInputUtil.EscapeKey
+        member x.Process kid = 
+            if kid.KeyInput = KeyInputUtil.EscapeKey then
                 ProcessResult.OfModeKind ModeKind.Normal
             else
                 ProcessResult.NotHandled

--- a/Src/VimCore/ExternalEdit.fs
+++ b/Src/VimCore/ExternalEdit.fs
@@ -9,9 +9,8 @@ type internal ExternalEditMode(_vimBufferData: IVimBufferData) =
         member x.ModeKind = ModeKind.ExternalEdit
         member x.CommandNames = Seq.empty
         member x.CanProcess keyInput = keyInput = KeyInputUtil.EscapeKey
-        member x.CanProcess ki = ki = KeyInputUtil.EscapeKey
-        member x.Process kid = 
-            if kid.KeyInput = KeyInputUtil.EscapeKey then
+        member x.Process keyInputData = 
+            if keyInputData.KeyInput = KeyInputUtil.EscapeKey then
                 ProcessResult.OfModeKind ModeKind.Normal
             else
                 ProcessResult.NotHandled

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -55,14 +55,18 @@ type internal HistorySession<'TData, 'TResult>
         let keyInput = keyInputData.KeyInput
         match Map.tryFind keyInput HistoryUtil.KeyInputMap with
         | Some HistoryCommand.Execute ->
-            // Enter key completes the action
+
+            // Enter key completes the action and updates the history if not
+            // mapped.
             let result = _historyClient.Completed _clientData _command
             if not keyInputData.WasMapped then
                 _historyClient.HistoryList.Add _command
             _inPasteWait <- false
             MappedBindResult.Complete result
         | Some HistoryCommand.Cancel ->
-            // Escape cancels the current search.  It does update the history though
+
+            // Escape cancels the current search and updates the history if not
+            // mapped.
             _historyClient.Cancelled _clientData
             if not keyInputData.WasMapped then
                 _historyClient.HistoryList.Add _command

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -53,13 +53,14 @@ type internal HistorySession<'TData, 'TResult>
     /// Process a single KeyInput value in the state machine. 
     member x.Process (keyInputData: KeyInputData) =
         let keyInput = keyInputData.KeyInput
+        let wasMapped = keyInputData.WasMapped
         match Map.tryFind keyInput HistoryUtil.KeyInputMap with
         | Some HistoryCommand.Execute ->
 
             // Enter key completes the action and updates the history if not
             // mapped.
-            let result = _historyClient.Completed _clientData _command keyInputData.WasMapped
-            if not keyInputData.WasMapped then
+            let result = _historyClient.Completed _clientData _command wasMapped
+            if not wasMapped then
                 _historyClient.HistoryList.Add _command
             _inPasteWait <- false
             MappedBindResult.Complete result
@@ -68,7 +69,7 @@ type internal HistorySession<'TData, 'TResult>
             // Escape cancels the current search and updates the history if not
             // mapped.
             _historyClient.Cancelled _clientData
-            if not keyInputData.WasMapped then
+            if not wasMapped then
                 _historyClient.HistoryList.Add _command
             _inPasteWait <- false
             MappedBindResult.Cancelled

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -58,7 +58,7 @@ type internal HistorySession<'TData, 'TResult>
 
             // Enter key completes the action and updates the history if not
             // mapped.
-            let result = _historyClient.Completed _clientData _command
+            let result = _historyClient.Completed _clientData _command keyInputData.WasMapped
             if not keyInputData.WasMapped then
                 _historyClient.HistoryList.Add _command
             _inPasteWait <- false

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -102,7 +102,7 @@ type internal IncrementalSearchSession
         let startPoint = start.Snapshot.CreateTrackingPoint(start.Position, PointTrackingMode.Negative)
         let historySession = HistoryUtil.CreateHistorySession x startPoint StringUtil.Empty vimBuffer
         _sessionState <- SessionState.Started historySession
-        historySession.CreateBindDataStorage().CreateBindData() |> convertBindData
+        historySession.CreateBindDataStorage().CreateMappedBindData().ConvertToBindData()
 
     member x.GetSearchResultAsync() =
         match _searchState with

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -264,7 +264,7 @@ type internal IncrementalSearchSession
         member x.ProcessCommand searchPoint searchText = x.RunActive searchPoint (fun () -> 
             x.RunSearchAsync searchPoint searchText
             searchPoint)
-        member x.Completed searchPoint searchText = x.RunActive (SearchResult.Error (_searchData, "Invalid Operation")) (fun () -> x.RunCompleted(searchPoint, searchText))
+        member x.Completed searchPoint searchText _ = x.RunActive (SearchResult.Error (_searchData, "Invalid Operation")) (fun () -> x.RunCompleted(searchPoint, searchText))
         member x.Cancelled _ = x.RunActive () (fun () -> x.RunCancel())
 
     interface IIncrementalSearchSession with

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -102,22 +102,6 @@ type internal IncrementalSearchSession
         let startPoint = start.Snapshot.CreateTrackingPoint(start.Position, PointTrackingMode.Negative)
         let historySession = HistoryUtil.CreateHistorySession x startPoint StringUtil.Empty vimBuffer
         _sessionState <- SessionState.Started historySession
-
-        let rec convertBindData (mappedBindData: MappedBindData<'T>): BindData<'T> =
-            {
-                KeyRemapMode = mappedBindData.KeyRemapMode
-                BindFunction = (fun keyInput ->
-                    KeyInputData.Create keyInput false
-                    |> mappedBindData.MappedBindFunction
-                    |> convertBindResult)
-            }
-        and convertBindResult (mappedBindResult: MappedBindResult<'T>): BindResult<'T> =
-            match mappedBindResult with
-            | MappedBindResult.Cancelled -> BindResult.Cancelled
-            | MappedBindResult.Complete result -> BindResult.Complete result
-            | MappedBindResult.Error -> BindResult.Error
-            | MappedBindResult.NeedMoreInput bindData -> BindResult.NeedMoreInput (convertBindData bindData)
-
         historySession.CreateBindDataStorage().CreateBindData() |> convertBindData
 
     member x.GetSearchResultAsync() =

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -102,7 +102,23 @@ type internal IncrementalSearchSession
         let startPoint = start.Snapshot.CreateTrackingPoint(start.Position, PointTrackingMode.Negative)
         let historySession = HistoryUtil.CreateHistorySession x startPoint StringUtil.Empty vimBuffer
         _sessionState <- SessionState.Started historySession
-        historySession.CreateBindDataStorage().CreateBindData()
+
+        let rec convertBindData (mappedBindData: MappedBindData<'T>): BindData<'T> =
+            {
+                KeyRemapMode = mappedBindData.KeyRemapMode
+                BindFunction = (fun keyInput ->
+                    KeyInputData.Create keyInput false
+                    |> mappedBindData.MappedBindFunction
+                    |> convertBindResult)
+            }
+        and convertBindResult (mappedBindResult: MappedBindResult<'T>): BindResult<'T> =
+            match mappedBindResult with
+            | MappedBindResult.Cancelled -> BindResult.Cancelled
+            | MappedBindResult.Complete result -> BindResult.Complete result
+            | MappedBindResult.Error -> BindResult.Error
+            | MappedBindResult.NeedMoreInput bindData -> BindResult.NeedMoreInput (convertBindData bindData)
+
+        historySession.CreateBindDataStorage().CreateBindData() |> convertBindData
 
     member x.GetSearchResultAsync() =
         match _searchState with

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -81,6 +81,17 @@ type KeyInput
     interface System.IComparable<KeyInput> with
         member x.CompareTo other = x.CompareTo other
 
+[<Sealed>]
+type KeyInputData
+    (
+        _keyInput: KeyInput,
+        _wasMapped: bool
+    ) =
+
+    member x.KeyInput = _keyInput
+    member x.WasMapped = _wasMapped
+    static member Create keyInput wasMapped = KeyInputData(keyInput, wasMapped)
+
 module KeyInputUtil = 
 
     [<Literal>]

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -90,15 +90,6 @@ type KeyInputData
 
     member x.KeyInput = _keyInput
     member x.WasMapped = _wasMapped
-    member x.Char = _keyInput.Char
-    member x.RawChar = _keyInput.RawChar
-    member x.Key = _keyInput.Key
-    member x.KeyModifiers = _keyInput.KeyModifiers
-    member x.HasKeyModifiers = _keyInput.HasKeyModifiers
-    member x.IsDigit = _keyInput.IsDigit
-    member x.IsArrowKey = _keyInput.IsArrowKey
-    member x.IsFunctionKey = _keyInput.IsFunctionKey
-    member x.IsMouseKey = _keyInput.IsMouseKey
     static member Create keyInput wasMapped = KeyInputData(keyInput, wasMapped)
 
 module KeyInputUtil = 

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -90,6 +90,15 @@ type KeyInputData
 
     member x.KeyInput = _keyInput
     member x.WasMapped = _wasMapped
+    member x.Char = _keyInput.Char
+    member x.RawChar = _keyInput.RawChar
+    member x.Key = _keyInput.Key
+    member x.KeyModifiers = _keyInput.KeyModifiers
+    member x.HasKeyModifiers = _keyInput.HasKeyModifiers
+    member x.IsDigit = _keyInput.IsDigit
+    member x.IsArrowKey = _keyInput.IsArrowKey
+    member x.IsFunctionKey = _keyInput.IsFunctionKey
+    member x.IsMouseKey = _keyInput.IsMouseKey
     static member Create keyInput wasMapped = KeyInputData(keyInput, wasMapped)
 
 module KeyInputUtil = 

--- a/Src/VimCore/KeyInput.fs
+++ b/Src/VimCore/KeyInput.fs
@@ -63,7 +63,7 @@ type KeyInput
             match _literal with
             | Some c -> StringUtil.GetDisplayString (string(c))
             | None -> "none"
-        System.String.Format("{0}:{1}:{2}", displayChar, x.Key, x.KeyModifiers);
+        System.String.Format("{0}:{1}:{2}", displayChar, x.Key, x.KeyModifiers)
 
     static member DefaultValue = KeyInput(VimKey.None, VimKeyModifiers.None, None)
     static member op_Equality(this,other) = System.Collections.Generic.EqualityComparer<KeyInput>.Default.Equals(this,other)
@@ -91,6 +91,9 @@ type KeyInputData
     member x.KeyInput = _keyInput
     member x.WasMapped = _wasMapped
     static member Create keyInput wasMapped = KeyInputData(keyInput, wasMapped)
+
+    override x.ToString() =
+        System.String.Format("{0}:{1}", x.KeyInput, x.WasMapped)
 
 module KeyInputUtil = 
 

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -51,6 +51,12 @@ type KeyInput =
     interface System.IComparable<KeyInput>
     interface System.IEquatable<KeyInput>
 
+[<Sealed>]
+type KeyInputData =
+    member KeyInput: KeyInput
+    member WasMapped: bool
+    static member Create: keyInput: KeyInput -> wasMapped: bool -> KeyInputData
+
 module KeyInputUtil = 
 
     /// The Null Key: VimKey.Null

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -51,19 +51,12 @@ type KeyInput =
     interface System.IComparable<KeyInput>
     interface System.IEquatable<KeyInput>
 
+/// Represents a key input together with whether the key input was the result
+/// of a mapping
 [<Sealed>]
 type KeyInputData =
     member KeyInput: KeyInput
     member WasMapped: bool
-    member Char: char
-    member RawChar: char option
-    member Key: VimKey
-    member KeyModifiers: VimKeyModifiers
-    member HasKeyModifiers: bool
-    member IsDigit: bool
-    member IsArrowKey: bool 
-    member IsFunctionKey: bool
-    member IsMouseKey: bool
     static member Create: keyInput: KeyInput -> wasMapped: bool -> KeyInputData
 
 module KeyInputUtil = 

--- a/Src/VimCore/KeyInput.fsi
+++ b/Src/VimCore/KeyInput.fsi
@@ -55,6 +55,15 @@ type KeyInput =
 type KeyInputData =
     member KeyInput: KeyInput
     member WasMapped: bool
+    member Char: char
+    member RawChar: char option
+    member Key: VimKey
+    member KeyModifiers: VimKeyModifiers
+    member HasKeyModifiers: bool
+    member IsDigit: bool
+    member IsArrowKey: bool 
+    member IsFunctionKey: bool
+    member IsMouseKey: bool
     static member Create: keyInput: KeyInput -> wasMapped: bool -> KeyInputData
 
 module KeyInputUtil = 

--- a/Src/VimCore/KeyMap.fs
+++ b/Src/VimCore/KeyMap.fs
@@ -144,7 +144,7 @@ type Mapper
                     processMapping lhs brokenMatchArray.[0].Value
                 elif lhs.Length = 1 then
                     // No mappings for the lhs so we are done
-                    result := KeyMappingResult.Mapped lhs
+                    result := KeyMappingResult.Unmapped lhs
                     isDone := true
                 else
                     // First character can't be mapped but the rest is still eligible for 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -136,7 +136,7 @@ type internal CommandMode
 
         _command <- ""
         _historySession <- Some historySession
-        _bindData <- historySession.CreateBindDataStorage().CreateBindData()
+        _bindData <- historySession.CreateBindDataStorage().CreateMappedBindData()
         _keepSelection <- false
         _isPartialCommand <- false
 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -18,9 +18,9 @@ type internal CommandMode
     let _parser = Parser(_buffer.Vim.GlobalSettings, _vimData)
     let _vimHost = _buffer.Vim.VimHost
 
-    static let BindDataError: BindData<int> = {
+    static let BindDataError: MappedBindData<int> = {
         KeyRemapMode = KeyRemapMode.None;
-        BindFunction = fun _ -> BindResult.Error
+        MappedBindFunction = fun _ -> MappedBindResult.Error
     }
 
     let mutable _command = StringUtil.Empty
@@ -78,8 +78,8 @@ type internal CommandMode
     member x.Process (keyInputData: KeyInputData) =
         let keyInput = keyInputData.KeyInput
 
-        match _bindData.BindFunction keyInput with
-        | BindResult.Complete _ ->
+        match _bindData.MappedBindFunction keyInputData with
+        | MappedBindResult.Complete _ ->
             _bindData <- BindDataError
 
             // It is possible for the execution of the command to change the mode (say :s.../c) 
@@ -90,13 +90,13 @@ type internal CommandMode
                     ProcessResult.Handled ModeSwitch.SwitchPreviousMode
             else 
                 ProcessResult.Handled ModeSwitch.NoSwitch
-        | BindResult.Cancelled ->
+        | MappedBindResult.Cancelled ->
             _bindData <- BindDataError
             ProcessResult.OfModeKind ModeKind.Normal
-        | BindResult.Error ->
+        | MappedBindResult.Error ->
             _bindData <- BindDataError
             ProcessResult.OfModeKind ModeKind.Normal
-        | BindResult.NeedMoreInput bindData ->
+        | MappedBindResult.NeedMoreInput bindData ->
             _bindData <- bindData
             ProcessResult.HandledNeedMoreInput
 

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -75,7 +75,8 @@ type internal CommandMode
             else 
                 selection.Clear()
 
-    member x.Process (keyInput: KeyInput) =
+    member x.Process (keyInputData: KeyInputData) =
+        let keyInput = keyInputData.KeyInput
 
         match _bindData.BindFunction keyInput with
         | BindResult.Complete _ ->
@@ -174,7 +175,7 @@ type internal CommandMode
         member x.InPasteWait = x.InPasteWait
         member x.ModeKind = ModeKind.Command
         member x.CanProcess keyInput = KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
-        member x.Process keyInput = x.Process keyInput
+        member x.Process keyInputData = x.Process keyInputData
         member x.OnEnter arg = x.OnEnter arg
         member x.OnLeave () = x.OnLeave ()
         member x.OnClose() = ()

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -76,8 +76,6 @@ type internal CommandMode
                 selection.Clear()
 
     member x.Process (keyInputData: KeyInputData) =
-        let keyInput = keyInputData.KeyInput
-
         match _bindData.MappedBindFunction keyInputData with
         | MappedBindResult.Complete _ ->
             _bindData <- BindDataError

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -1209,7 +1209,8 @@ type internal InsertMode
             None
 
     /// Process the KeyInput value
-    member x.Process keyInput = 
+    member x.Process (keyInputData: KeyInputData) = 
+        let keyInput = keyInputData.KeyInput
         _isInProcess <- true
         try
             let result = x.ProcessCore keyInput
@@ -1522,7 +1523,7 @@ type internal InsertMode
         member x.ModeKind = x.ModeKind
         member x.CanProcess keyInput = x.CanProcess keyInput
         member x.IsDirectInsert keyInput = x.IsDirectInsert keyInput
-        member x.Process keyInput = x.Process keyInput
+        member x.Process keyInputData = x.Process keyInputData
         member x.OnEnter arg = x.OnEnter arg
         member x.OnLeave () = x.OnLeave ()
         member x.OnClose() = x.OnClose ()

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -361,9 +361,9 @@ type internal NormalMode
         || _runner.DoesCommandStartWith keyInput
     
     member x.Process (keyInputData: KeyInputData) = 
-        let keyInput = keyInputData.KeyInput
 
         // Update the text of the command so long as this isn't a control character 
+        let keyInput = keyInputData.KeyInput
         if not (CharUtil.IsControl keyInput.Char) then
             let command = _data.Command + keyInput.Char.ToString()
             _data <- { _data with Command = command }

--- a/Src/VimCore/Modes_Normal_NormalMode.fs
+++ b/Src/VimCore/Modes_Normal_NormalMode.fs
@@ -360,7 +360,8 @@ type internal NormalMode
         KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
         || _runner.DoesCommandStartWith keyInput
     
-    member x.Process (keyInput: KeyInput) = 
+    member x.Process (keyInputData: KeyInputData) = 
+        let keyInput = keyInputData.KeyInput
 
         // Update the text of the command so long as this isn't a control character 
         if not (CharUtil.IsControl keyInput.Char) then
@@ -402,7 +403,7 @@ type internal NormalMode
         member x.CommandNames = x.CommandNames
         member x.ModeKind = ModeKind.Normal
         member x.CanProcess keyInput = x.CanProcess keyInput
-        member x.Process keyInput = x.Process keyInput
+        member x.Process keyInputData = x.Process keyInputData
         member x.OnEnter arg = x.OnEnter arg
         member x.OnLeave () = ()
         member x.OnClose() = _eventHandlers.DisposeAll()

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -192,8 +192,8 @@ type internal SubstituteConfirmMode
         member x.ModeKind = ModeKind.SubstituteConfirm
         member x.VimTextBuffer = _vimTextBuffer
 
-        member x.Process kid = 
-            let ki = kid.KeyInput
+        member x.Process keyInputData = 
+            let keyInput = keyInputData.KeyInput
 
             // Guard against the case where confirm mode is incorrectly entered
             match _confirmData with
@@ -202,7 +202,7 @@ type internal SubstituteConfirmMode
             | Some data -> 
 
                 // It's valid so process the input
-                match Map.tryFind ki _commandMap with
+                match Map.tryFind keyInput _commandMap with
                 | None -> ProcessResult.Handled ModeSwitch.NoSwitch
                 | Some func -> func data |> ProcessResult.Handled
 

--- a/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
+++ b/Src/VimCore/Modes_SubstituteConfirm_SubstituteConfirmMode.fs
@@ -192,7 +192,8 @@ type internal SubstituteConfirmMode
         member x.ModeKind = ModeKind.SubstituteConfirm
         member x.VimTextBuffer = _vimTextBuffer
 
-        member x.Process ki = 
+        member x.Process kid = 
+            let ki = kid.KeyInput
 
             // Guard against the case where confirm mode is incorrectly entered
             match _confirmData with

--- a/Src/VimCore/Modes_Visual_SelectMode.fs
+++ b/Src/VimCore/Modes_Visual_SelectMode.fs
@@ -180,7 +180,8 @@ type internal SelectMode
         KeyInputUtil.IsCore keyInput && not keyInput.IsMouseKey
         || _runner.DoesCommandStartWith keyInput
 
-    member x.Process keyInput = 
+    member x.Process (keyInputData: KeyInputData) = 
+        let keyInput = keyInputData.KeyInput
 
         let processResult = 
             if keyInput = KeyInputUtil.EscapeKey then
@@ -267,7 +268,7 @@ type internal SelectMode
         member x.CommandNames =  Commands |> Seq.map (fun binding -> binding.KeyInputSet)
         member x.ModeKind = _modeKind
         member x.CanProcess keyInput = x.CanProcess keyInput
-        member x.Process keyInput =  x.Process keyInput
+        member x.Process keyInputData =  x.Process keyInputData
         member x.OnEnter modeArgument = x.OnEnter modeArgument
         member x.OnLeave () = x.OnLeave()
         member x.OnClose() = x.OnClose()

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -208,13 +208,13 @@ type internal VisualMode
         let useVirtualSpace = _vimTextBuffer.UseVirtualSpace
         VisualSelection.CreateForVirtualSelection _textView _visualKind selectionKind tabStop useVirtualSpace
 
-    member x.Process (kid: KeyInputData) =  
-        let ki = kid.KeyInput
+    member x.Process (keyInputData: KeyInputData) =  
+        let keyInput = keyInputData.KeyInput
 
         // Save the last visual selection at the global level for use with [count]V|v except
         // in the case of <Esc>. This <Esc> exception is not a documented behavior but exists
         // experimentally. 
-        match ki, _vimTextBuffer.LastVisualSelection with
+        match keyInput, _vimTextBuffer.LastVisualSelection with
         | keyInput, Some lastVisualSelection when keyInput <> KeyInputUtil.EscapeKey ->
             let vimData = _vimBufferData.Vim.VimData
             match StoredVisualSelection.CreateFromVisualSpan lastVisualSelection.VisualSpan with
@@ -223,10 +223,10 @@ type internal VisualMode
         | _ -> ()
 
         let result = 
-            if ki = KeyInputUtil.EscapeKey && x.ShouldHandleEscape then
+            if keyInput = KeyInputUtil.EscapeKey && x.ShouldHandleEscape then
                 ProcessResult.Handled ModeSwitch.SwitchPreviousMode
             else
-                match _runner.Run ki with
+                match _runner.Run keyInput with
                 | BindResult.NeedMoreInput _ -> 
                     _selectionTracker.UpdateSelection()
                     ProcessResult.HandledNeedMoreInput
@@ -258,7 +258,7 @@ type internal VisualMode
                 | BindResult.Error ->
                     _selectionTracker.UpdateSelection()
                     _operations.Beep()
-                    if ki.IsMouseKey then
+                    if keyInput.IsMouseKey then
                         ProcessResult.NotHandled
                     else
                         ProcessResult.Handled ModeSwitch.NoSwitch

--- a/Src/VimCore/Modes_Visual_VisualMode.fs
+++ b/Src/VimCore/Modes_Visual_VisualMode.fs
@@ -208,7 +208,8 @@ type internal VisualMode
         let useVirtualSpace = _vimTextBuffer.UseVirtualSpace
         VisualSelection.CreateForVirtualSelection _textView _visualKind selectionKind tabStop useVirtualSpace
 
-    member x.Process (ki: KeyInput) =  
+    member x.Process (kid: KeyInputData) =  
+        let ki = kid.KeyInput
 
         // Save the last visual selection at the global level for use with [count]V|v except
         // in the case of <Esc>. This <Esc> exception is not a documented behavior but exists
@@ -320,7 +321,7 @@ type internal VisualMode
         member x.CommandNames = x.CommandNames
         member x.ModeKind = _modeKind
         member x.CanProcess keyInput = x.CanProcess keyInput
-        member x.Process keyInput =  x.Process keyInput
+        member x.Process keyInputData =  x.Process keyInputData
         member x.OnEnter modeArgument = x.OnEnter modeArgument
         member x.OnLeave () = x.OnLeave()
         member x.OnClose() = x.OnClose()

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -339,6 +339,9 @@ type internal VimBuffer
             | None -> false
 
         match x.GetKeyInputMapping keyInput with
+        | KeyMappingResult.Unmapped keyInputSet -> 
+            mapped keyInputSet
+
         | KeyMappingResult.Mapped keyInputSet -> 
             mapped keyInputSet
 
@@ -610,6 +613,9 @@ type internal VimBuffer
                 let keyMappingResult = x.GetKeyMappingCore remainingSet.Value x.KeyRemapMode
                 remainingSet := 
                     match keyMappingResult with
+                    | KeyMappingResult.Unmapped mappedKeyInputSet -> 
+                        processUnmappedSet mappedKeyInputSet
+                        KeyInputSet.Empty
                     | KeyMappingResult.Mapped mappedKeyInputSet -> 
                         mapCount := mapCount.Value + 1
                         processMappedSet mappedKeyInputSet

--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -471,7 +471,8 @@ type internal VimBuffer
 
     /// Process the single KeyInput value.  No mappings are considered here.  The KeyInput is 
     /// simply processed directly
-    member x.ProcessOneKeyInput (keyInput: KeyInput) =
+    member x.ProcessOneKeyInput (keyInput: KeyInput) (wasMapped: bool) =
+        let keyInputData = KeyInputData.Create keyInput wasMapped
 
         let processResult = 
 
@@ -491,7 +492,7 @@ type internal VimBuffer
                     // The <nop> key should have no affect
                     ProcessResult.Handled ModeSwitch.NoSwitch
                 else
-                    let result = x.Mode.Process keyInput
+                    let result = x.Mode.Process keyInputData
 
                     // Certain types of commands can always cause the current mode to be exited for
                     // the previous one time command mode.  Handle them here
@@ -589,19 +590,21 @@ type internal VimBuffer
 
         // Process the KeyInput values in the given set to completion without considering
         // any further key mappings
-        let processSet (keyInputSet: KeyInputSet) = 
-            let mutable error = false
+        let processSet (keyInputSet: KeyInputSet) (wasMapped: bool) =
             for keyInput in keyInputSet.KeyInputs do
                 if not (isError ()) then 
                     let keyInput = x.GetNonKeypadEquivalent keyInput
-                    processResult := x.ProcessOneKeyInput keyInput
+                    processResult := x.ProcessOneKeyInput keyInput wasMapped
+
+        let processUnmappedSet keyInputSet = processSet keyInputSet false
+        let processMappedSet keyInputSet = processSet keyInputSet true
 
         while remainingSet.Value.Length > 0 && not (isError ()) do
             match x.KeyRemapMode with
             | KeyRemapMode.None -> 
                 // There is no mode for the current key stroke but may be for the subsequent
                 // ones in the set.  Process the first one only here 
-                remainingSet.Value.FirstKeyInput.Value |> KeyInputSetUtil.Single |> processSet
+                remainingSet.Value.FirstKeyInput.Value |> KeyInputSetUtil.Single |> processUnmappedSet
                 remainingSet := remainingSet.Value.Rest
             | _ -> 
                 let keyMappingResult = x.GetKeyMappingCore remainingSet.Value x.KeyRemapMode
@@ -609,11 +612,11 @@ type internal VimBuffer
                     match keyMappingResult with
                     | KeyMappingResult.Mapped mappedKeyInputSet -> 
                         mapCount := mapCount.Value + 1
-                        processSet mappedKeyInputSet
+                        processMappedSet mappedKeyInputSet
                         KeyInputSet.Empty
                     | KeyMappingResult.PartiallyMapped (mappedKeyInputSet, remainingSet) ->
                         mapCount := mapCount.Value + 1
-                        processSet mappedKeyInputSet
+                        processMappedSet mappedKeyInputSet
                         remainingSet
                     | KeyMappingResult.NeedsMoreInput keyInputSet -> 
                         _bufferedKeyInput <- Some keyInputSet
@@ -692,16 +695,16 @@ type internal VimBuffer
             //  :imap ii long
             //
             // Then type 'i' in insert mode and wait for the time out.  It will print 'short'
-            let keyInputSet = 
+            let keyInputSet, wasMapped = 
                 let keyMapping = 
                     _keyMap.GetKeyMappingsForMode x.KeyRemapMode
                     |> Seq.tryFind (fun keyMapping -> keyMapping.Left = keyInputSet)
                 match keyMapping with
-                | None -> keyInputSet
-                | Some keyMapping -> keyMapping.Right
+                | None -> keyInputSet, false
+                | Some keyMapping -> keyMapping.Right, true
 
             keyInputSet.KeyInputs
-            |> Seq.iter (fun keyInput -> x.ProcessOneKeyInput keyInput |> ignore)
+            |> Seq.iter (fun keyInput -> x.ProcessOneKeyInput keyInput wasMapped |> ignore)
  
             if _isClosed && not x.IsProcessingInput then
                 _postClosedEvent.Trigger x   

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -747,6 +747,11 @@ namespace Vim.UnitTest
             return mode.CanProcess(KeyInputUtil.VimKeyToKeyInput(key));
         }
 
+        public static ProcessResult Process(this IMode mode, KeyInput keyInput)
+        {
+            return mode.Process(KeyInputData.Create(keyInput, false));
+        }
+
         public static ProcessResult Process(this IMode mode, VimKey key)
         {
             return mode.Process(KeyInputUtil.VimKeyToKeyInput(key));

--- a/Src/VimTestUtils/Extensions.cs
+++ b/Src/VimTestUtils/Extensions.cs
@@ -699,6 +699,12 @@ namespace Vim.UnitTest
             return (KeyMappingResult.Mapped)res;
         }
 
+        public static KeyMappingResult.Unmapped AsUnmapped(this KeyMappingResult res)
+        {
+            Assert.True(res.IsUnmapped);
+            return (KeyMappingResult.Unmapped)res;
+        }
+
         public static KeyMappingResult.PartiallyMapped AsPartiallyMapped(this KeyMappingResult res)
         {
             Assert.True(res.IsPartiallyMapped);
@@ -710,6 +716,11 @@ namespace Vim.UnitTest
             if (res.IsMapped)
             {
                 return res.AsMapped().KeyInputSet;
+            }
+
+            if (res.IsUnmapped)
+            {
+                return res.AsUnmapped().KeyInputSet;
             }
 
             var partialMap = res.AsPartiallyMapped();

--- a/Src/VimTestUtils/Mock/MockNormalMode.cs
+++ b/Src/VimTestUtils/Mock/MockNormalMode.cs
@@ -50,7 +50,7 @@ namespace Vim.UnitTest.Mock
             throw new NotImplementedException();
         }
 
-        public ProcessResult Process(KeyInput value)
+        public ProcessResult Process(KeyInputData value)
         {
             throw new NotImplementedException();
         }

--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -74,9 +74,9 @@ namespace Vim.VisualStudio.Implementation.Misc
                 return false;
             }
 
-            if (result.IsMapped)
+            if (result.IsMapped || result.IsUnmapped)
             {
-                var set = ((KeyMappingResult.Mapped)result).KeyInputSet;
+                var set = result.IsMapped ? ((KeyMappingResult.Mapped)result).KeyInputSet : ((KeyMappingResult.Unmapped)result).KeyInputSet;
                 if (set.Length != 1)
                 {
                     mapped = null;

--- a/Test/VimCoreTest/HistorySessionTest.cs
+++ b/Test/VimCoreTest/HistorySessionTest.cs
@@ -64,7 +64,7 @@ namespace Vim.UnitTest
         {
             _client = new Client() { HistoryList = new HistoryList(), RegisterMap = Vim.RegisterMap };
             _historySession = HistoryUtil.CreateHistorySession(_client, 0, "", null);
-            _bindData = _historySession.CreateBindDataStorage().CreateBindData();
+            _bindData = _historySession.CreateBindDataStorage().CreateMappedBindData();
         }
 
         public void ProcessNotation(string notation)

--- a/Test/VimCoreTest/HistorySessionTest.cs
+++ b/Test/VimCoreTest/HistorySessionTest.cs
@@ -58,7 +58,7 @@ namespace Vim.UnitTest
 
         private readonly Client _client;
         private readonly IHistorySession<int, int> _historySession;
-        private BindData<int> _bindData;
+        private MappedBindData<int> _bindData;
 
         public HistorySessionTest()
         {
@@ -75,11 +75,12 @@ namespace Vim.UnitTest
             }
         }
 
-        public void Process(KeyInput keyInput)
+        public void Process(KeyInput keyInput, bool wasMapped = false)
         {
-            var result = _bindData.BindFunction.Invoke(keyInput);
+            var keyInputData = KeyInputData.Create(keyInput, wasMapped);
+            var result = _bindData.MappedBindFunction.Invoke(keyInputData);
             _bindData = result.IsNeedMoreInput
-                ? ((BindResult<int>.NeedMoreInput)result).BindData
+                ? ((MappedBindResult<int>.NeedMoreInput)result).MappedBindData
                 : null;
         }
 

--- a/Test/VimCoreTest/HistorySessionTest.cs
+++ b/Test/VimCoreTest/HistorySessionTest.cs
@@ -22,11 +22,11 @@ namespace Vim.UnitTest
 
             public int? CancelledValue { get; set; }
 
-            public Tuple<int, string> CompletedValue { get; set; }
+            public Tuple<int, string, bool> CompletedValue { get; set; }
 
             public int? CompletedReturn { get; set; }
 
-            public Tuple<int, string> ProcessValue { get; set; }
+            public Tuple<int, string, bool> ProcessValue { get; set; }
 
             public int? ProcessReturn { get; set; }
 
@@ -41,15 +41,15 @@ namespace Vim.UnitTest
                 CancelledValue = value;
             }
 
-            public int Completed(int data, string command)
+            public int Completed(int data, string command, bool wasMapped)
             {
-                CompletedValue = Tuple.Create(data, command);
+                CompletedValue = Tuple.Create(data, command, wasMapped);
                 return CompletedReturn ?? data;
             }
 
             public int ProcessCommand(int data, string command)
             {
-                ProcessValue = Tuple.Create(data, command);
+                ProcessValue = Tuple.Create(data, command, false);
                 return ProcessReturn ?? data;
             }
         }

--- a/Test/VimCoreTest/KeyMapTest.cs
+++ b/Test/VimCoreTest/KeyMapTest.cs
@@ -34,7 +34,7 @@ namespace Vim.UnitTest
             var result = _map.GetKeyMappingResult(lhs, mode);
             if (lhs.Length == 1)
             {
-                Assert.True(result.IsMapped);
+                Assert.True(result.IsMapped || result.IsUnmapped);
             }
             else
             {
@@ -55,7 +55,7 @@ namespace Vim.UnitTest
         {
             mode = mode ?? KeyRemapMode.Normal;
             var ret = _map.GetKeyMappingResult(lhs, mode);
-            Assert.True(ret.IsMapped);
+            Assert.True(ret.IsMapped || ret.IsUnmapped);
             Assert.Equal(KeyInputSetUtil.OfString(expected), ret.GetMappedKeyInputs());
         }
 

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -133,7 +133,7 @@ namespace Vim.UnitTest
             public void ExceptionDuringProcessing()
             {
                 var normal = CreateAndAddNormalMode(MockBehavior.Loose);
-                normal.Setup(x => x.Process(It.IsAny<KeyInput>())).Throws(new Exception());
+                normal.Setup(x => x.Process(It.IsAny<KeyInputData>())).Throws(new Exception());
                 _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
                 _textView.SetText("hello world");
 
@@ -385,7 +385,7 @@ namespace Vim.UnitTest
                 var normal = CreateAndAddNormalMode(MockBehavior.Loose);
 
                 int keyCount = 0;
-                normal.Setup(x => x.Process(It.IsAny<KeyInput>()))
+                normal.Setup(x => x.Process(It.IsAny<KeyInputData>()))
                       .Callback(() =>
                                 {
                                     if (keyCount == 0)
@@ -413,7 +413,7 @@ namespace Vim.UnitTest
                 _vimBuffer.PostClosed += delegate { count++; };
 
                 var normal = CreateAndAddNormalMode(MockBehavior.Loose);
-                normal.Setup(x => x.Process(It.Is<KeyInput>(k => k.Equals(KeyInputUtil.CharToKeyInput('A')))))
+                normal.Setup(x => x.Process(It.Is<KeyInputData>(k => k.KeyInput.Equals(KeyInputUtil.CharToKeyInput('A')))))
                       .Callback(() => { _vimBuffer.Close(); })
                       .Returns(ProcessResult.NewHandled(ModeSwitch.NoSwitch));
                 
@@ -794,7 +794,7 @@ namespace Vim.UnitTest
             public void SwitchModeOneTimeCommand_SetProperty()
             {
                 var mode = CreateAndAddInsertMode(MockBehavior.Loose);
-                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.NewHandled(ModeSwitch.NewSwitchModeOneTimeCommand(ModeKind.Normal)));
+                mode.Setup(x => x.Process(It.IsAny<KeyInputData>())).Returns(ProcessResult.NewHandled(ModeSwitch.NewSwitchModeOneTimeCommand(ModeKind.Normal)));
                 _vimBuffer.SwitchMode(ModeKind.Insert, ModeArgument.None);
                 _vimBuffer.Process('c');
                 Assert.True(_vimBuffer.InOneTimeCommand.IsSome(ModeKind.Insert));
@@ -807,7 +807,7 @@ namespace Vim.UnitTest
             public void Process_HandleSwitchPreviousMode()
             {
                 var normal = CreateAndAddNormalMode(MockBehavior.Loose);
-                normal.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.NewHandled(ModeSwitch.SwitchPreviousMode));
+                normal.Setup(x => x.Process(It.IsAny<KeyInputData>())).Returns(ProcessResult.NewHandled(ModeSwitch.SwitchPreviousMode));
                 _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
                 _vimBuffer.Process('l');
                 Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
@@ -836,7 +836,7 @@ namespace Vim.UnitTest
             public void Process_OneTimeCommand_NeedMoreInputDoesNothing()
             {
                 var mode = CreateAndAddNormalMode(MockBehavior.Loose);
-                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.HandledNeedMoreInput);
+                mode.Setup(x => x.Process(It.IsAny<KeyInputData>())).Returns(ProcessResult.HandledNeedMoreInput);
                 _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
                 _vimBufferRaw.InOneTimeCommand = FSharpOption.Create(ModeKind.Replace);
                 _vimBuffer.Process('c');
@@ -851,7 +851,7 @@ namespace Vim.UnitTest
             public void Process_OneTimeCommand_Escape()
             {
                 var mode = CreateAndAddNormalMode(MockBehavior.Loose);
-                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.Error);
+                mode.Setup(x => x.Process(It.IsAny<KeyInputData>())).Returns(ProcessResult.Error);
                 mode.Setup(x => x.CanProcess(It.IsAny<KeyInput>())).Returns(false);
                 _vimBuffer.SwitchMode(ModeKind.Normal, ModeArgument.None);
                 _vimBufferRaw.InOneTimeCommand = FSharpOption.Create(ModeKind.Replace);
@@ -868,7 +868,7 @@ namespace Vim.UnitTest
             public void Process_OneTimeCommand_VisualMode_Handled()
             {
                 var mode = CreateAndAddVisualLineMode(MockBehavior.Loose);
-                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.NewHandled(ModeSwitch.NoSwitch));
+                mode.Setup(x => x.Process(It.IsAny<KeyInputData>())).Returns(ProcessResult.NewHandled(ModeSwitch.NoSwitch));
                 _vimBuffer.SwitchMode(ModeKind.VisualLine, ModeArgument.None);
                 _vimBufferRaw.InOneTimeCommand = FSharpOption.Create(ModeKind.Replace);
                 _vimBuffer.Process('l');
@@ -883,7 +883,7 @@ namespace Vim.UnitTest
             public void Process_OneTimeCommand_VisualMode_SwitchPreviousMode()
             {
                 var mode = CreateAndAddVisualLineMode(MockBehavior.Loose);
-                mode.Setup(x => x.Process(It.IsAny<KeyInput>())).Returns(ProcessResult.NewHandled(ModeSwitch.SwitchPreviousMode));
+                mode.Setup(x => x.Process(It.IsAny<KeyInputData>())).Returns(ProcessResult.NewHandled(ModeSwitch.SwitchPreviousMode));
                 _vimBuffer.SwitchMode(ModeKind.VisualLine, ModeArgument.None);
                 _vimBufferRaw.InOneTimeCommand = FSharpOption.Create(ModeKind.Replace);
                 _vimBuffer.Process('l');


### PR DESCRIPTION
#### Issues

- Closes #2318

#### Discussion

I tried so many times to fix this bug without making a complete mess of things and I think I've finally come up with a fairly clean and minimally invasive solution. The issue is conceptually a simple one:

- Suppress the normal mechanism of adding a command to the command history when that command was executed as the result of a keyboard mapping.

The problem is that whether a given key input is mapped and the point at which we execute a command are removed from each other by many processing layers. To solve the problem, we have to carry metadata about the key input along with the key input as it weaves its way through the many layers. As a result, the time-honored `IMode.Process(KeyInput)` method has now become `IMode.Process(KeyInputData)` and the key mapping infrastructure now has to report whether a given key input was the result of a mapping as it is doing its work.

The hardest part about this was that the `BindData<'T>` family of types that pervades the key processing of VsVim is "hard-coded" to operate on the `KeyInput` type. I tried four different approaches to extend these types to be able to also operate on a `KeyInputData`.

1) I tried simply changing `BindData<'T>` so that it is "hard-coded" to operate on the `KeyInputData` type. This led to sweeping changes of code that hasn't changed for years and is utterly uninterested in the benefit that `KeyInputData` provides.

2) I tried making `BindData<'T>` "more" generic and thus, becomes `BindData<'S, 'T>` where `'S` is usually `KeyInput` but can be `KeyInputData`. This also leads to sweeping changes because much of the unaffected code needs to supply or facilitate the resolution of an addition type. Furthermore, `BindData` which is already obtuse, becomes even more unwieldy to understand and maintain.

3) I tried make approach 2 but named it `GenericBindData<'S, 'T>` and then created specialized subtypes `BindData<'T>` as an alias for `GenericBindData<KeyInput, 'T>` and `MappedBindData<'T>` as an alias for `GenericBindData<KeyInputData, 'T>`. This **almost** worked, because F# supports generic type aliases, but unfortunately, C# does not. That meant new sweeping changes to the test code which is written almost entirely in C#.

4) Finally, I created a parallel type called `MappedBindData<'T>` that is just like `BindData<'T>` except that it operates on `KeyInputData` instead of `KeyInput`. This approach led to far less sweeping changes, but has two disadvantages. First, it leads to some code repetition that seems like it "ought" to be factored out as commonality. Second, we need a way to convert from one kind o bind data types to the other kind so that the old code and the new code can interoperate at the interfaces.

I ended up going with the fourth approach and accepted its trade-offs as a reasonable compromise to keeping the changes from spiraling out of control.