### PR TITLE
Shutdown Dispatcher properly in tests

### DIFF
--- a/Src/VimTestUtils/Utilities/StaTestFramework.cs
+++ b/Src/VimTestUtils/Utilities/StaTestFramework.cs
@@ -1,0 +1,28 @@
+﻿using Xunit.Sdk;
+using Xunit.Abstractions;
+using System.Windows.Data;
+using System;
+using System.Linq;
+
+namespace Vim.UnitTest.Utilities
+{
+    public sealed class StaTestFramework : XunitTestFramework, IDisposable
+    {
+        public static bool IsCreated { get; private set; }
+
+        public StaTestFramework() : this(null)
+        {
+        }
+
+        public StaTestFramework(IMessageSink messageSink) : base(messageSink)
+        {
+            IsCreated = true;
+        }
+
+        void IDisposable.Dispose()
+        {
+            StaContext.Default.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/Src/VimTestUtils/Utilities/StaTestFrameworkAttribute.cs
+++ b/Src/VimTestUtils/Utilities/StaTestFrameworkAttribute.cs
@@ -1,0 +1,17 @@
+﻿using Xunit.Sdk;
+using Xunit.Abstractions;
+using System.Windows.Data;
+using System;
+using System.Linq;
+
+namespace Vim.UnitTest.Utilities
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    [TestFrameworkDiscoverer("Vim.UnitTest.Utilities.StaTestFrameworkTypeDiscoverer", "Vim.UnitTest.Utils")]
+    public sealed class StaTestFrameworkAttribute : Attribute, ITestFrameworkAttribute
+    {
+        public StaTestFrameworkAttribute()
+        {
+        }
+    }
+}

--- a/Src/VimTestUtils/Utilities/StaTestFrameworkTypeDiscoverer.cs
+++ b/Src/VimTestUtils/Utilities/StaTestFrameworkTypeDiscoverer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading;
+using Vim.Extensions;
+using System.Windows.Threading;
+using System.Diagnostics;
+using Xunit.Sdk;
+using Xunit.Abstractions;
+
+namespace Vim.UnitTest.Utilities
+{
+    public sealed class StaTestFrameworkTypeDiscoverer : ITestFrameworkTypeDiscoverer
+    {
+        public StaTestFrameworkTypeDiscoverer()
+        {
+
+        }
+
+        Type ITestFrameworkTypeDiscoverer.GetTestFrameworkType(IAttributeInfo attribute) => typeof(StaTestFramework);
+    }
+}

--- a/Src/VimTestUtils/Utilities/WpfTestRunner.cs
+++ b/Src/VimTestUtils/Utilities/WpfTestRunner.cs
@@ -26,8 +26,6 @@ namespace Vim.UnitTest.Utilities
         /// </summary>
         private static readonly TimeSpan HangMitigatingTimeout = TimeSpan.FromMinutes(1);
 
-        private static string s_wpfFactRequirementReason;
-
         public WpfTestSharedData SharedData { get; }
 
         public WpfTestRunner(
@@ -50,6 +48,7 @@ namespace Vim.UnitTest.Utilities
         protected override Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
         {
             SharedData.ExecutingTest(TestMethod);
+            Debug.Assert(StaTestFramework.IsCreated);
 
             var taskScheduler = new SynchronizationContextTaskScheduler(StaContext.Default.DispatcherSynchronizationContext);
             return Task.Factory.StartNew(async () =>
@@ -58,29 +57,11 @@ namespace Vim.UnitTest.Utilities
 
                 using (await SharedData.TestSerializationGate.DisposableWaitAsync(CancellationToken.None))
                 {
-                    // Reset our flag ensuring that part of this test actually needs WpfFact
-                    s_wpfFactRequirementReason = null;
-
                     // Just call back into the normal xUnit dispatch process now that we are on an STA Thread with no synchronization context.
                     var invoker = new XunitTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource);
                     return await invoker.RunAsync();
                 }
             }, CancellationTokenSource.Token, TaskCreationOptions.None, taskScheduler).Unwrap();
-        }
-
-        /// <summary>
-        /// Asserts that the test is running on a <see cref="WpfFactAttribute"/> or <see cref="WpfTheoryAttribute"/>
-        /// test method, and records the reason for requiring the use of an STA thread.
-        /// </summary>
-        internal static void RequireWpfFact(string reason)
-        {
-            var context = SynchronizationContext.Current.GetEffectiveSynchronizationContext();
-            if (!(context is DispatcherSynchronizationContext))
-            {
-                throw new InvalidOperationException($"This test requires {nameof(WpfFactAttribute)} because '{reason}' but is missing {nameof(WpfFactAttribute)}. Either the attribute should be changed, or the reason it needs an STA thread audited.");
-            }
-
-            s_wpfFactRequirementReason = reason;
         }
     }
 }

--- a/Test/VimCoreTest/Properties/AssemblyInfo.cs
+++ b/Test/VimCoreTest/Properties/AssemblyInfo.cs
@@ -1,7 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Vim.UnitTest.Utilities;
 using Xunit;
 
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
-
+[assembly: StaTestFramework]

--- a/Test/VimWpfTest/Properties/AssemblyInfo.cs
+++ b/Test/VimWpfTest/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Vim.UnitTest.Utilities;
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: StaTestFramework]

--- a/Test/VsVimSharedTest/Properties/AssemblyInfo.cs
+++ b/Test/VsVimSharedTest/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Vim.UnitTest.Utilities;
 using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: StaTestFramework]


### PR DESCRIPTION
This change uses the `ITestFramework` hook in xUnit to allow for
graceful shutdown of the `Dispatcher` instance used to run our tests.
The `ITestFramework.Dispose` method is both

1. Called before `AppDomain.Unload`
1. Called after all tests have completed executing

This means it's the ideal place to tear down the `Dispatcher` and STA
thread created to run the tests.

Other places considered for tear down:

1. `AppDomain.CurrentDomain.DomainUnload`: this event fires as the
`AppDomain` is being torn down meaning the `Dispatcher` or its child
objects could have already been finalized. Indeed this is the case on
most of the machines tested. This meant calling
`Dispatcher.BeginInvokeShutdown` was unreliable as the underlying HWND
handles may have been finalized.
1. `StaContext.Dispose`: this is not a part of any hook in xUnit hence
is never actually invoked.

Note: this may end up breaking source based discovery for tests in Test
Explorer but normal build based discovery will continue working.

closes #2563