### PR TITLE
Fix semantics of inverted collections in vim regular expressions

### DIFF
--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -581,7 +581,7 @@ module VimRegexFactory =
             false
 
     /// Clear state related to previous parsing
-    let clearState (data: VimRegexBuilder) =
+    let ClearState (data: VimRegexBuilder) =
         let isStartOfPattern = data.IsStartOfPattern
         let isStartOfCollection = data.IsStartOfCollection
         let isAlternate = data.IsAlternate
@@ -594,14 +594,14 @@ module VimRegexFactory =
     let ConvertCharAsNormal (data: VimRegexBuilder) c = 
         if not (TryAppendNamedCollection data c) then
             data.AppendEscapedChar c
-        clearState data |> ignore
+        ClearState data |> ignore
 
     /// Convert the given character as a special character.  This is done independent of any 
     /// magic setting.
     let ConvertCharAsSpecial (data: VimRegexBuilder) c = 
 
         let isStartOfPattern, isStartOfCollection, isAlternate =
-            clearState data
+            ClearState data
 
         match c with
         | '.' ->

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -4561,6 +4561,24 @@ namespace Vim.UnitTest
                     _vimBuffer.ProcessNotation(@"1G/bat\ndog", enter: true);
                     Assert.Equal(_textBuffer.GetLine(1).Start, _textView.GetCaretPoint());
                 }
+
+                [WpfFact]
+                public void InvertedCollection_NoMatchEndOfLine()
+                {
+                    // Reported in issue #1471.
+                    Create("Hello", "World", "");
+                    _assertOnErrorMessage = false;
+                    _vimBuffer.ProcessNotation(@"/o[^o]\+W", enter: true);
+                    Assert.Equal(_textView.GetPointInLine(0, 0), _textView.GetCaretPoint());
+                }
+
+                [WpfFact]
+                public void InvertedCollection_MatchEndOfLine()
+                {
+                    Create("Hello", "World", "");
+                    _vimBuffer.ProcessNotation(@"/o\_[^o]\+W", enter: true);
+                    Assert.Equal(_textView.GetPointInLine(0, 4), _textView.GetCaretPoint());
+                }
             }
 
             public sealed class OffsetTest : IncrementalSearchTest

--- a/Test/VimCoreTest/VimRegexFactoryTest.cs
+++ b/Test/VimCoreTest/VimRegexFactoryTest.cs
@@ -15,41 +15,41 @@ namespace Vim.UnitTest
 
         public sealed class CreateForSubstituteFlagsTest : VimRegexFactoryTest
         {
-            private VimRegex Create(string pattern, SubstituteFlags flags)
+            private VimRegex Create(string pattern, SubstituteFlags flags = SubstituteFlags.None)
             {
                 var regex = VimRegexFactory.CreateForSubstituteFlags(pattern, _globalSettings, flags);
                 Assert.True(regex.IsSome());
                 return regex.Value;
             }
-            [Fact]
 
             /// <summary>
             /// If there is no explicit case option in the flags then the ignore case setting
             /// should be respected
             /// </summary>
-            private void RespectIgnoreCaseSetting()
+            [Fact]
+            public void RespectIgnoreCaseSetting()
             {
                 _globalSettings.IgnoreCase = true;
                 var regex = Create("test", SubstituteFlags.None);
                 Assert.True(regex.Regex.Options.HasFlag(RegexOptions.IgnoreCase));
             }
-            [Fact]
 
             /// <summary>
             /// The flag should trump the setting
             /// </summary>
-            private void RespectIgnoreCaseFlag()
+            [Fact]
+            public void RespectIgnoreCaseFlag()
             {
                 _globalSettings.IgnoreCase = false;
                 var regex = Create("test", SubstituteFlags.IgnoreCase);
                 Assert.True(regex.Regex.Options.HasFlag(RegexOptions.IgnoreCase));
             }
-            [Fact]
 
             /// <summary>
             /// Smart case should be considered if there is no explicit case flag
             /// </summary>
-            private void RespectSmartCaseSetting()
+            [Fact]
+            public void RespectSmartCaseSetting()
             {
                 _globalSettings.IgnoreCase = true;
                 _globalSettings.SmartCase = true;
@@ -58,7 +58,7 @@ namespace Vim.UnitTest
             }
 
             /// <summary>
-            /// The ignore flag should overrid esmart case
+            /// The ignore flag should override smart case
             /// </summary>
             [Fact]
             public void IgnoreSmartCaseWithIgnoreCaseFlag()
@@ -67,6 +67,34 @@ namespace Vim.UnitTest
                 _globalSettings.SmartCase = true;
                 var regex = Create("Test", SubstituteFlags.IgnoreCase);
                 Assert.True(regex.Regex.Options.HasFlag(RegexOptions.IgnoreCase));
+            }
+
+            [Fact]
+            public void Collection()
+            {
+                var regex = Create(@"[a]");
+                Assert.Equal(@"[a]", regex.RegexPattern);
+            }
+
+            [Fact]
+            public void AlternateCollection()
+            {
+                var regex = Create(@"\_[a]");
+                Assert.Equal(@"[\r\na]", regex.RegexPattern);
+            }
+
+            [Fact]
+            public void InvertedCollection()
+            {
+                var regex = Create(@"[^a]");
+                Assert.Equal(@"[^\r\na]", regex.RegexPattern);
+            }
+
+            [Fact]
+            public void AlternateInvertedCollection()
+            {
+                var regex = Create(@"\_[^a]");
+                Assert.Equal(@"[^a]", regex.RegexPattern);
             }
         }
     }


### PR DESCRIPTION
#### Issues

- Closes #1471

#### Discussion

Here's a summary of how Vim collection semantics work:

| Vim Regex | BCL Regex | Vim Help Topic |
| - | - | - |
| `[a]` | `[a]` |  `/[` |
| `[^a]` | `[^\r\na]` |  `/[\n]` |
| `\_[a]` | `[\r\na]` | `/[\n]` |
| `\_[^a]` | `[^a]` | `/[\n]` |