### PR TITLE
Suppress vimrc error messages in first command margin

### DIFF
--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -2260,7 +2260,8 @@ type VimInterpreter
         try
             while not parser.IsDone do
                 let lineCommand = parser.ParseNextCommand()
-                _statusUtil.ContextLineNumber <- Some parser.ContextLineNumber
+                if lines.Length <> 1 then
+                    _statusUtil.ContextLineNumber <- Some parser.ContextLineNumber
                 x.RunLineCommand lineCommand |> ignore
         finally
             _statusUtil.ContextLineNumber <- None

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -2264,14 +2264,19 @@ type VimInterpreter
     // Actually parse and run all of the commands which are included in the script
     member x.RunScript lines = 
         let parser = Parser(_globalSettings, _vimData, lines)
+        let previousContextLineNumber = _statusUtil.ContextLineNumber
         try
             while not parser.IsDone do
-                if lines.Length <> 1 then
-                    _statusUtil.ContextLineNumber <- Some parser.ContextLineNumber
+                let contextLineNumber = parser.ContextLineNumber
                 let lineCommand = parser.ParseNextCommand()
+                _statusUtil.ContextLineNumber <-
+                    if lines.Length <> 1 then
+                        Some contextLineNumber
+                    else
+                        None
                 x.RunLineCommand lineCommand |> ignore
         finally
-            _statusUtil.ContextLineNumber <- None
+            _statusUtil.ContextLineNumber <- previousContextLineNumber
    
     member x.InterpretSymbolicPath (symbolicPath: SymbolicPath) =
         let rec inner (sb:System.Text.StringBuilder) sp =

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -342,6 +342,8 @@ and [<Sealed>] Parser
 
     member x.IsDone = _tokenizer.IsAtEndOfLine && _lineIndex  + 1 >= _lines.Length
 
+    member x.ContextLineNumber = _lineIndex
+
     /// Parse out the token stream so long as it matches the input.  If everything matches
     /// the tokens will be consumed and 'true' will be returned.  Else 'false' will be 
     /// returned and the token stream will be unchanged

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -512,8 +512,11 @@ and [<Sealed>] Parser
 
     /// Create a line number annotated parse error
     member x.ParseError message =
-        let lineMessage = _lineIndex + 1 |> Resources.Parser_OnLine
-        sprintf "%s: %s" lineMessage message
+        if _lines.Length <> 1 then
+            let lineMessage = _lineIndex + 1 |> Resources.Parser_OnLine
+            sprintf "%s: %s" lineMessage message
+        else
+            message
         |> LineCommand.ParseError
 
     /// Parse out the mapclear variants. 

--- a/Src/VimCore/Interpreter_Parser.fsi
+++ b/Src/VimCore/Interpreter_Parser.fsi
@@ -18,6 +18,8 @@ type Parser =
 
     member IsDone: bool
 
+    member ContextLineNumber: int
+
     /// Parse the next complete command from the source.  Command pairs like :func and :endfunc
     /// will be returned as a single Function command.  
     member ParseNextCommand: unit -> LineCommand

--- a/Src/VimCore/Resources.fs
+++ b/Src/VimCore/Resources.fs
@@ -61,7 +61,6 @@ module internal Resources =
     let CommandMode_NotSupported msg = sprintf "Command not currently supported: %s" msg
     let CommandMode_NotSupported_SourceNormal = "source! commands are not currently supported"
     let CommandMode_NotSupported_KeyMapping lhs rhs = sprintf "The key mapping %s -> %s is not currently supported" lhs rhs
-    let CommandMode_UnknownOption optionName = sprintf "Unknown option: %s" optionName
     let CommandMode_InvalidArgument name = sprintf "Invalid argument: %s" name
     let CommandMode_InvalidValue name value = sprintf "Invalid value given for %s: %s" name value
     let CommandMode_CannotRun command = sprintf "Cannot run \"%s\"" command

--- a/Src/VimCore/Resources.fs
+++ b/Src/VimCore/Resources.fs
@@ -123,6 +123,7 @@ module internal Resources =
     let Interpreter_InvalidConversionToString t = sprintf "Using %s as a String" t
     let Interpreter_DivByZero = "Attempt to divide by zero. Not supported."
     let Interpreter_ModByZero = "Attempt to mod by zero. Not supported."
+    let Interpreter_ErrorsSourcing path = sprintf "Errors sourcing \"%s\":" path
 
     let Regex_Unknown = "Unknown error building regex"
     let Regex_UnmatchedParen = "Unmatched ("

--- a/Src/VimCore/Vim.fs
+++ b/Src/VimCore/Vim.fs
@@ -745,6 +745,10 @@ type internal Vim
                 _vimRcLocalSettings <- LocalSettings.Copy vimBuffer.LocalSettings
                 _vimRcWindowSettings <- WindowSettings.Copy vimBuffer.WindowSettings
                 _vimRcState <- VimRcState.LoadSucceeded (vimRcPath, errorList.ToArray())
+
+                if errorList.Count <> 0 then
+                    VimTrace.TraceError("Errors loading rc file: {0}", vimRcPath.FilePath)
+                    VimTrace.TraceError(String.Join(Environment.NewLine, errorList))
             finally
                 // Remove the event handlers
                 bag.DisposeAll()
@@ -783,6 +787,7 @@ type internal Vim
             if not (_vimHost.ShouldIncludeRcFile vimRcPath) then
                 None
             else
+                VimTrace.TraceInfo("Trying rc file: {0}", vimRcPath.FilePath)
                 _fileSystem.ReadAllLines vimRcPath.FilePath
                 |> Option.map (fun lines -> (vimRcPath, lines)))
 

--- a/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
+++ b/Src/VimWpf/Implementation/CommandMargin/CommandMarginController.cs
@@ -169,7 +169,9 @@ namespace Vim.UI.Wpf.Implementation.CommandMargin
             var message = string.Empty;
             if (_isFirstCommandMargin)
             {
-                if (_vimBuffer.Vim.VimRcState is VimRcState.LoadSucceeded rcState && rcState.Errors.Length != 0)
+                if (_vimBuffer.Vim.VimRcState is VimRcState.LoadSucceeded rcState &&
+                        rcState.VimRcPath.VimRcKind != VimRcKind.VimRc &&
+                        rcState.Errors.Length != 0)
                 {
                     message = string.Join(Environment.NewLine, rcState.Errors);
                 }

--- a/Test/VimCoreTest/ExpressionInterpreterTest.cs
+++ b/Test/VimCoreTest/ExpressionInterpreterTest.cs
@@ -13,7 +13,8 @@ namespace Vim.UnitTest
         public ExpressionInterpreterTest()
         {
             _statusUtil = new Mock<IStatusUtil>(MockBehavior.Strict);
-            _interpreter = new ExpressionInterpreter(_statusUtil.Object, null, null, new Dictionary<string, VariableValue>(), null);
+            var interpreterStatusUtil = new InterpreterStatusUtil(_statusUtil.Object);
+            _interpreter = new ExpressionInterpreter(interpreterStatusUtil, null, null, new Dictionary<string, VariableValue>(), null);
         }
 
         private VariableValue Run(string expr)

--- a/Test/VimCoreTest/InterpreterTest.cs
+++ b/Test/VimCoreTest/InterpreterTest.cs
@@ -952,7 +952,7 @@ namespace Vim.UnitTest
                 Create("");
                 _vimBuffer.LocalSettings.ExpandTab = false;
                 ParseAndRun(@"set blah?");
-                Assert.Equal(Resources.CommandMode_UnknownOption("blah"), _statusUtil.LastError);
+                Assert.Equal(Resources.Interpreter_UnknownOption("blah"), _statusUtil.LastError);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/VimIntegrationTest.cs
+++ b/Test/VimCoreTest/VimIntegrationTest.cs
@@ -310,7 +310,12 @@ autocmd BufEnter *.html set ts=12
 
                 var errorArray = ((VimRcState.LoadSucceeded)_vim.VimRcState).Errors;
                 Assert.Single(errorArray);
-                Assert.Equal(Resources.Interpreter_UnknownOption("foo"), errorArray[0]);
+                var expectedLine = 1; // empty lines removed
+                var expectedVariable = "foo";
+                var embeddedError = Resources.Interpreter_UnknownOption(expectedVariable);
+                var lineNumber = Resources.Parser_OnLine(expectedLine);
+                var expectedError = $"{lineNumber}: {embeddedError}";
+                Assert.Equal(expectedError, errorArray[0]);
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/VimIntegrationTest.cs
+++ b/Test/VimCoreTest/VimIntegrationTest.cs
@@ -304,13 +304,15 @@ autocmd BufEnter *.html set ts=12
             public void Errors()
             {
                 var text = @"
+    set hlsearch
     set foo=1
 ";
                 Run(text);
+                Assert.True(_globalSettings.HighlightSearch);
 
                 var errorArray = ((VimRcState.LoadSucceeded)_vim.VimRcState).Errors;
                 Assert.Single(errorArray);
-                var expectedLine = 1; // empty lines removed
+                var expectedLine = 2; // empty lines removed
                 var expectedVariable = "foo";
                 var embeddedError = Resources.Interpreter_UnknownOption(expectedVariable);
                 var lineNumber = Resources.Parser_OnLine(expectedLine);


### PR DESCRIPTION
#### Issues

- Continuing work on closed issue #1153
- Closes #2585

#### Discussion

It turns out that vimrc error messages are reported through another mechanism (a toast notification). As a result, now only vsvimrc error messages will be reported in the first command margin.

In addition, while PR #2545 added line numbers to parser errors, many commands only produce errors during interpretation, e.g. invalid options. To address this deficiency, this PR also adds line number annotations to interpreter errors.
