### PR TITLE
Pass double quotes to HostCommand

### DIFF
--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -1875,6 +1875,9 @@ and [<Sealed>] Parser
         | None -> x.ParseError Resources.Parser_Error
         | Some command ->
             x.SkipBlanks()
+            /// we want to do: vsc Edit.FindinFiles "foo bar" /lookin:"Current Project"
+            /// so we need to allow double quotes and parse them into argument
+            _tokenizer.TokenizerFlags <- _tokenizer.TokenizerFlags ||| TokenizerFlags.AllowDoubleQuote
             let argument = x.ParseRestOfLine()
             LineCommand.HostCommand (hasBang, command, argument)
 


### PR DESCRIPTION
- Closes #2622

I have got another oneliner ;-)
Right now this does not work
`:vsc Edit.FindinFiles "foo bar" /lookin:"Current Project"`
because the part after " is ignored. We need to allow it and pass it through.
The real use for it of course, is to generate these vsc through mappings, like here:
https://github.com/VsVim/VsVim/issues/1516