### PR TITLE
Force full string before parsing JSON

### DIFF
--- a/Scripts/Build.ps1
+++ b/Scripts/Build.ps1
@@ -108,7 +108,7 @@ function Upload-Vsix() {
 
 function Get-MSBuildPath() {
   $vsWhere = Join-Path $toolsDir "vswhere.exe"
-  $vsInfo = Exec-Command $vsWhere "-latest -format json -requires Microsoft.Component.MSBuild" | ConvertFrom-Json
+  $vsInfo = Exec-Command $vsWhere "-latest -format json -requires Microsoft.Component.MSBuild" | Out-String | ConvertFrom-Json
 
   # use first matching instance
   $vsInfo = $vsInfo[0]


### PR DESCRIPTION
The return of `Exec-Command` can be a collection of `string` entries.
Need to use `Out-String` to force it into a single `string` before
attempting to parse out the JSON.