### PR TITLE
Coding guidelines update

### DIFF
--- a/Documentation/CodingGuidelines.md
+++ b/Documentation/CodingGuidelines.md
@@ -11,7 +11,7 @@ The F# code is the following:
 - **DO** add a space between
     - Values and arithmic operators and comparisions
     - Names and Values in record initializer expressions
-    - Names and their types `(foo : bar)`
+    - Names and explicit types `(text: string)`
     - Keywords and open parens `with get (`, `if (`, `elif (`
     - Discriminated Union Names and open parens
 
@@ -23,7 +23,7 @@ The F# code is the following:
  the two code bases should use the same pattern to make it simpler to understand the code.
 
 - Last is inclusive
-- End is not inclusive
+- End is exclusive
 - Util classes should contain Create methods to create 
 - Editor APIs 
     - APIs taking a count should return an option or explicitly guard against count being too large.  Users


### PR DESCRIPTION
Quite some time ago the coding style for identifier declarations changed
to be `text: string` instead of `text : string`. The commit was
7e48591cc770bf85b2dcb3fe9713b0d9608abac4.

That commit though did not update the coding guidelines to reflect the
new approach.