### PR TITLE
Support command line editing keys such as left arrow in mappings

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4644,14 +4644,14 @@ type EditableCommand =
             x
 
     /// Left arrow key operation
-    member x.LeftArrow () =
+    member x.Left () =
         if x.CaretPosition > 0 then
             EditableCommand(x.Text, x.CaretPosition - 1)
         else
             x
 
     /// Right arrow key operation
-    member x.RightArrow () =
+    member x.Right () =
         if x.CaretPosition < x.Text.Length then
             EditableCommand(x.Text, x.CaretPosition + 1)
         else

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4610,6 +4610,7 @@ type HistoryList () =
 [<StructuralEquality>]
 [<NoComparison>]
 [<Struct>]
+[<DebuggerDisplay("{ToString(),nq}")>]
 type EditableCommand =
 
     val private _text: string
@@ -4675,11 +4676,15 @@ type EditableCommand =
         else
             x
 
-    /// Insert text operation
-    member x.Insert text =
+    /// Insert text at the caret
+    member x.InsertText text =
         let before = x.Text.Substring(0, x.CaretPosition)
         let after = x.Text.Substring(x.CaretPosition)
         EditableCommand(before + text + after, x.CaretPosition + text.Length)
+
+    /// Display representation of an editable command
+    override x.ToString() =
+        String.Format("Text = '{0}', CaretPosition = {1}", x.Text, x.CaretPosition)
 
     /// The empty editable command
     static member Empty =

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -4632,7 +4632,7 @@ type EditableCommand =
 
     /// Home key operation
     member x.Home () =
-        if x._caretPosition <> 0 then
+        if x.CaretPosition <> 0 then
             EditableCommand(x.Text, 0)
         else
             x
@@ -4684,7 +4684,7 @@ type EditableCommand =
 
     /// Display representation of an editable command
     override x.ToString() =
-        String.Format("Text = '{0}', CaretPosition = {1}", x.Text, x.CaretPosition)
+        sprintf "Text = %s, CaretPosition = %i" x.Text x.CaretPosition
 
     /// The empty editable command
     static member Empty =

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -528,8 +528,9 @@ module CharUtil =
             yield UnicodeCategory.DecimalDigitNumber
             yield UnicodeCategory.LetterNumber
             yield UnicodeCategory.OtherNumber
-            // Not separators
-            //yield UnicodeCategory.SpaceSeparator
+            // Space separators
+            yield UnicodeCategory.SpaceSeparator
+            // Not other separators
             //yield UnicodeCategory.LineSeparator
             //yield UnicodeCategory.ParagraphSeparator
             // Not control, etc.

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -13,6 +13,10 @@ type HistoryState =
 [<NoComparison>]
 [<NoEquality>]
 type HistoryCommand =
+    | Home
+    | End
+    | LeftArrow
+    | RightArrow
     | Previous
     | Next
     | Execute
@@ -73,6 +77,22 @@ type internal HistorySession<'TData, 'TResult>
                 _historyClient.HistoryList.Add _command.Text
             _inPasteWait <- false
             MappedBindResult.Cancelled
+        | Some HistoryCommand.Home ->
+                _command.Home()
+                |> x.ResetCommand
+                x.CreateBindResult()
+        | Some HistoryCommand.End ->
+                _command.End()
+                |> x.ResetCommand
+                x.CreateBindResult()
+        | Some HistoryCommand.LeftArrow ->
+                _command.LeftArrow()
+                |> x.ResetCommand
+                x.CreateBindResult()
+        | Some HistoryCommand.RightArrow ->
+                _command.RightArrow()
+                |> x.ResetCommand
+                x.CreateBindResult()
         | Some HistoryCommand.Back ->
             match _command.Text.Length with
             | 0 -> 
@@ -196,6 +216,10 @@ and internal HistoryUtil ()  =
 
         let set1 = 
             seq { 
+                yield ("<Home>", HistoryCommand.Home)
+                yield ("<End>", HistoryCommand.End)
+                yield ("<Left>", HistoryCommand.LeftArrow)
+                yield ("<Right>", HistoryCommand.RightArrow)
                 yield ("<C-p>", HistoryCommand.Previous)
                 yield ("<C-n>", HistoryCommand.Next)
                 yield ("<C-R>", HistoryCommand.Paste)

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -122,10 +122,15 @@ type internal HistorySession<'TData, 'TResult>
         | None -> 
             if _inPasteWait then
                 x.ProcessPaste keyInput
-            else
+            elif
+                CharUtil.IsPrintable keyInput.Char
+                && not keyInput.HasKeyModifiers
+            then
                 keyInput.Char.ToString()
                 |> _command.InsertText
                 |> x.ResetCommand
+                x.CreateBindResult()
+            else
                 x.CreateBindResult()
 
     member x.ProcessPaste keyInput = 

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -15,13 +15,14 @@ type HistoryState =
 type HistoryCommand =
     | Home
     | End
-    | LeftArrow
-    | RightArrow
+    | Left
+    | Right
     | Previous
     | Next
     | Execute
     | Cancel
-    | Back
+    | Backspace
+    | Delete
     | Paste
     | PasteSpecial of WordKind: WordKind
     | Clear
@@ -78,22 +79,22 @@ type internal HistorySession<'TData, 'TResult>
             _inPasteWait <- false
             MappedBindResult.Cancelled
         | Some HistoryCommand.Home ->
-                _command.Home()
-                |> x.ResetCommand
-                x.CreateBindResult()
+            _command.Home()
+            |> x.ResetCommand
+            x.CreateBindResult()
         | Some HistoryCommand.End ->
-                _command.End()
-                |> x.ResetCommand
-                x.CreateBindResult()
-        | Some HistoryCommand.LeftArrow ->
-                _command.LeftArrow()
-                |> x.ResetCommand
-                x.CreateBindResult()
-        | Some HistoryCommand.RightArrow ->
-                _command.RightArrow()
-                |> x.ResetCommand
-                x.CreateBindResult()
-        | Some HistoryCommand.Back ->
+            _command.End()
+            |> x.ResetCommand
+            x.CreateBindResult()
+        | Some HistoryCommand.Left ->
+            _command.Left()
+            |> x.ResetCommand
+            x.CreateBindResult()
+        | Some HistoryCommand.Right ->
+            _command.Right()
+            |> x.ResetCommand
+            x.CreateBindResult()
+        | Some HistoryCommand.Backspace ->
             match _command.Text.Length with
             | 0 -> 
                 _historyClient.Cancelled _clientData
@@ -102,6 +103,10 @@ type internal HistorySession<'TData, 'TResult>
                 _command.Backspace()
                 |> x.ResetCommand
                 x.CreateBindResult()
+        | Some HistoryCommand.Delete ->
+            _command.Delete()
+            |> x.ResetCommand
+            x.CreateBindResult()
         | Some HistoryCommand.Previous ->
             x.ProcessPrevious()
         | Some HistoryCommand.Next ->
@@ -218,8 +223,8 @@ and internal HistoryUtil ()  =
             seq { 
                 yield ("<Home>", HistoryCommand.Home)
                 yield ("<End>", HistoryCommand.End)
-                yield ("<Left>", HistoryCommand.LeftArrow)
-                yield ("<Right>", HistoryCommand.RightArrow)
+                yield ("<Left>", HistoryCommand.Left)
+                yield ("<Right>", HistoryCommand.Right)
                 yield ("<C-p>", HistoryCommand.Previous)
                 yield ("<C-n>", HistoryCommand.Next)
                 yield ("<C-R>", HistoryCommand.Paste)
@@ -234,7 +239,8 @@ and internal HistoryUtil ()  =
                 yield ("<Enter>", HistoryCommand.Execute)
                 yield ("<Up>", HistoryCommand.Previous)
                 yield ("<Down>", HistoryCommand.Next)
-                yield ("<BS>", HistoryCommand.Back)
+                yield ("<BS>", HistoryCommand.Backspace)
+                yield ("<Del>", HistoryCommand.Delete)
                 yield ("<Esc>", HistoryCommand.Cancel)
             }
             |> Seq.map (fun (name, command) -> 

--- a/Src/VimCore/HistoryUtil.fs
+++ b/Src/VimCore/HistoryUtil.fs
@@ -124,7 +124,7 @@ type internal HistorySession<'TData, 'TResult>
                 x.ProcessPaste keyInput
             else
                 keyInput.Char.ToString()
-                |> _command.Insert
+                |> _command.InsertText
                 |> x.ResetCommand
                 x.CreateBindResult()
 
@@ -134,7 +134,7 @@ type internal HistorySession<'TData, 'TResult>
         | Some name -> 
             let register = _registerMap.GetRegister name
             register.StringValue
-            |> _command.Insert
+            |> _command.InsertText
             |> x.ResetCommand
 
         _inPasteWait <- false
@@ -154,7 +154,7 @@ type internal HistorySession<'TData, 'TResult>
             | None -> x.ResetCommand _command
             | Some cw ->
                 cw.Span.GetText()
-                |> _command.Insert
+                |> _command.InsertText
                 |> x.ResetCommand
 
             x.CreateBindResult()

--- a/Src/VimCore/HistoryUtil.fsi
+++ b/Src/VimCore/HistoryUtil.fsi
@@ -6,7 +6,7 @@ namespace Vim
 type internal HistoryUtil = 
 
     /// Begin a history related operation
-    static member CreateHistorySession<'TData, 'TResult> : IHistoryClient<'TData, 'TResult> -> 'TData -> string -> IVimBuffer option -> IHistorySession<'TData, 'TResult>
+    static member CreateHistorySession<'TData, 'TResult> : IHistoryClient<'TData, 'TResult> -> 'TData -> EditableCommand -> IVimBuffer option -> IHistorySession<'TData, 'TResult>
 
     /// The set of KeyInput values which history considers to be a valid command
     static member CommandNames: KeyInput list

--- a/Src/VimCore/Modes_Command_CommandMode.fs
+++ b/Src/VimCore/Modes_Command_CommandMode.fs
@@ -23,19 +23,24 @@ type internal CommandMode
         MappedBindFunction = fun _ -> MappedBindResult.Error
     }
 
-    let mutable _command = StringUtil.Empty
+    let mutable _command = EditableCommand.Empty
     let mutable _historySession: IHistorySession<int, int> option = None
     let mutable _bindData = BindDataError
     let mutable _keepSelection = false
     let mutable _isPartialCommand = false
 
-    /// Currently queued up command string
-    member x.Command 
+    /// Currently queued up editable command
+    member x.EditableCommand 
         with get() = _command
         and set value = 
             if value <> _command then
                 _command <- value
                 _commandChangedEvent.Trigger x
+
+    /// Currently queued up command string
+    member x.Command 
+        with get() = x.EditableCommand.Text
+        and set value = x.EditableCommand <- EditableCommand(value)
 
     member x.InPasteWait = 
         match _historySession with
@@ -104,19 +109,19 @@ type internal CommandMode
         // The ProcessCommand call back just means a new command state was reached.  Until it's
         // completed we just keep updating the current state 
         let processCommand command = 
-            x.Command <- command
+            x.EditableCommand <- command
             0
 
         /// Run the specified command
         let completed command wasMapped =
-            x.Command <- StringUtil.Empty
+            x.EditableCommand <- EditableCommand.Empty
             x.ParseAndRunInput command wasMapped
             x.MaybeClearSelection false
             0
 
         /// User cancelled input.  Reset the selection
         let cancelled () = 
-            x.Command <- StringUtil.Empty
+            x.EditableCommand <- EditableCommand.Empty
             x.MaybeClearSelection true
 
         // First key stroke.  Create a history client and get going
@@ -127,7 +132,7 @@ type internal CommandMode
                 member this.RemapMode = KeyRemapMode.Command
                 member this.Beep() = _operations.Beep()
                 member this.ProcessCommand _ command = processCommand command
-                member this.Completed _ command wasMapped = completed command wasMapped
+                member this.Completed _ command wasMapped = completed command.Text wasMapped
                 member this.Cancelled _ = cancelled ()
             }
         HistoryUtil.CreateHistorySession historyClient 0 _command (Some _buffer)
@@ -135,7 +140,7 @@ type internal CommandMode
     member x.OnEnter (arg: ModeArgument) = 
         let historySession = x.CreateHistorySession()
 
-        _command <- ""
+        _command <- EditableCommand.Empty
         _historySession <- Some historySession
         _bindData <- historySession.CreateBindDataStorage().CreateMappedBindData()
         _keepSelection <- false
@@ -148,11 +153,12 @@ type internal CommandMode
             | _ -> StringUtil.Empty
 
         if not (StringUtil.IsNullOrEmpty commandText) then
-            x.ChangeCommand commandText
+            EditableCommand(commandText)
+            |> x.ChangeCommand
 
     member x.OnLeave() = 
         x.MaybeClearSelection true
-        _command <- StringUtil.Empty
+        _command <- EditableCommand.Empty
         _historySession <- None
         _bindData <- BindDataError
         _keepSelection <- false
@@ -160,16 +166,19 @@ type internal CommandMode
 
     /// Called externally to update the command.  Do this by modifying the history 
     /// session.  If we aren't in command mode currently then this is a no-op 
-    member x.ChangeCommand command = 
+    member x.ChangeCommand (command: EditableCommand) = 
         match _historySession with
         | None -> ()
         | Some historySession -> historySession.ResetCommand command
 
     interface ICommandMode with
         member x.VimTextBuffer = _buffer.VimTextBuffer
-        member x.Command 
-            with get() = x.Command
+        member x.EditableCommand 
+            with get() = x.EditableCommand
             and set value = x.ChangeCommand value
+        member x.Command
+            with get() = x.Command
+            and set value = EditableCommand(value) |> x.ChangeCommand
         member x.CommandNames = HistoryUtil.CommandNames |> Seq.map KeyInputSetUtil.Single
         member x.InPasteWait = x.InPasteWait
         member x.ModeKind = ModeKind.Command

--- a/Src/VimWpf/ICommandMarginUtil.cs
+++ b/Src/VimWpf/ICommandMarginUtil.cs
@@ -9,6 +9,6 @@ namespace Vim.UI.Wpf
     {
         void SetMarginVisibility(IVimBuffer vimBuffer, bool commandMarginVisible);
 
-        string GetStatus(IVimBuffer vimBuffer);
+        EditableCommand GetStatus(IVimBuffer vimBuffer);
     }
 }

--- a/Src/VsVimShared/Implementation/Misc/StatusBarAdapter.cs
+++ b/Src/VsVimShared/Implementation/Misc/StatusBarAdapter.cs
@@ -54,7 +54,7 @@ namespace Vim.VisualStudio.Implementation.Misc
 
                 var vimBuffer = _vim.FocusedBuffer.SomeOrDefault(null);
                 var status = vimBuffer != null
-                    ? _commandMarginUtil.GetStatus(vimBuffer)
+                    ? _commandMarginUtil.GetStatus(vimBuffer).Text
                     : "";
 
                 if (status.Length == 0)

--- a/Test/VimCoreTest/HistorySessionTest.cs
+++ b/Test/VimCoreTest/HistorySessionTest.cs
@@ -41,15 +41,15 @@ namespace Vim.UnitTest
                 CancelledValue = value;
             }
 
-            public int Completed(int data, string command, bool wasMapped)
+            public int Completed(int data, EditableCommand command, bool wasMapped)
             {
-                CompletedValue = Tuple.Create(data, command, wasMapped);
+                CompletedValue = Tuple.Create(data, command.Text, wasMapped);
                 return CompletedReturn ?? data;
             }
 
-            public int ProcessCommand(int data, string command)
+            public int ProcessCommand(int data, EditableCommand command)
             {
-                ProcessValue = Tuple.Create(data, command, false);
+                ProcessValue = Tuple.Create(data, command.Text, false);
                 return ProcessReturn ?? data;
             }
         }
@@ -63,7 +63,7 @@ namespace Vim.UnitTest
         public HistorySessionTest()
         {
             _client = new Client() { HistoryList = new HistoryList(), RegisterMap = Vim.RegisterMap };
-            _historySession = HistoryUtil.CreateHistorySession(_client, 0, "", null);
+            _historySession = HistoryUtil.CreateHistorySession(_client, 0, EditableCommand.Empty, null);
             _bindData = _historySession.CreateBindDataStorage().CreateMappedBindData();
         }
 
@@ -106,7 +106,7 @@ namespace Vim.UnitTest
             {
                 ProcessNotation("<C-R>");
                 Assert.True(_historySession.InPasteWait);
-                _historySession.ResetCommand("any");
+                _historySession.ResetCommand(new EditableCommand("any"));
                 Assert.False(_historySession.InPasteWait);
             }
 

--- a/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
@@ -54,7 +54,23 @@ namespace Vim.UI.Wpf.UnitTest
             _vimBuffer.Process("Q");
             Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
             var expectedCaretPosition = command.Length - 2;
-            Assert.Equal(new EditableCommand(command, expectedCaretPosition), _vimBuffer.CommandMode.EditableCommand);
+            var expectedCommand = new EditableCommand(command, expectedCaretPosition);
+            Assert.Equal(expectedCommand, _vimBuffer.CommandMode.EditableCommand);
+            Assert.Equal(":" + command, _control.CommandLineTextBox.Text);
+            Assert.Equal(expectedCaretPosition + 1, _control.CommandLineTextBox.SelectionStart);
+        }
+
+        [WpfFact]
+        public void UnmappedSpecialKey()
+        {
+            var command = "%s//g";
+            _vimBuffer.Process($":map Q :{command}<PageUp>", enter: true);
+            Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+            _vimBuffer.Process("Q");
+            Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+            var expectedCaretPosition = command.Length;
+            var expectedCommand = new EditableCommand(command, expectedCaretPosition);
+            Assert.Equal(expectedCommand, _vimBuffer.CommandMode.EditableCommand);
             Assert.Equal(":" + command, _control.CommandLineTextBox.Text);
             Assert.Equal(expectedCaretPosition + 1, _control.CommandLineTextBox.SelectionStart);
         }

--- a/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
@@ -44,8 +44,11 @@ namespace Vim.UI.Wpf.UnitTest
             Assert.Equal(Resources.Common_NoWriteSinceLastChange, _control.CommandLineTextBox.Text);
         }
 
+        /// <summary>
+        /// A mapped left arrow key should affect the caret position
+        /// </summary>
         [WpfFact]
-        public void MapLeft()
+        public void MappedLeft()
         {
             // Reported in issue #1103.
             var command = "%s//g";
@@ -60,8 +63,12 @@ namespace Vim.UI.Wpf.UnitTest
             Assert.Equal(expectedCaretPosition + 1, _control.CommandLineTextBox.SelectionStart);
         }
 
+        /// <summary>
+        /// A mapped special key without a binding should not result in a null
+        /// character being inserted into the command
+        /// </summary>
         [WpfFact]
-        public void UnmappedSpecialKey()
+        public void MappedSpecialKey()
         {
             var command = "%s//g";
             _vimBuffer.Process($":map Q :{command}<PageUp>", enter: true);

--- a/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
@@ -43,5 +43,20 @@ namespace Vim.UI.Wpf.UnitTest
             _vimBuffer.ProcessNotation(":q<CR>");
             Assert.Equal(Resources.Common_NoWriteSinceLastChange, _control.CommandLineTextBox.Text);
         }
+
+        [WpfFact]
+        public void MapLeft()
+        {
+            // Reported in issue #1103.
+            var command = "%s//g";
+            _vimBuffer.Process($":map Q :{command}<Left><Left>", enter: true);
+            Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);
+            _vimBuffer.Process("Q");
+            Assert.Equal(ModeKind.Command, _vimBuffer.ModeKind);
+            var expectedCaretPosition = command.Length - 2;
+            Assert.Equal(new EditableCommand(command, expectedCaretPosition), _vimBuffer.CommandMode.EditableCommand);
+            Assert.Equal(":" + command, _control.CommandLineTextBox.Text);
+            Assert.Equal(expectedCaretPosition + 1, _control.CommandLineTextBox.SelectionStart);
+        }
     }
 }

--- a/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerIntegrationTest.cs
@@ -70,6 +70,7 @@ namespace Vim.UI.Wpf.UnitTest
         [WpfFact]
         public void MappedSpecialKey()
         {
+            // Reported in #2683.
             var command = "%s//g";
             _vimBuffer.Process($":map Q :{command}<PageUp>", enter: true);
             Assert.Equal(ModeKind.Normal, _vimBuffer.ModeKind);

--- a/Test/VimWpfTest/CommandMarginControllerTest.cs
+++ b/Test/VimWpfTest/CommandMarginControllerTest.cs
@@ -225,9 +225,11 @@ namespace Vim.UI.Wpf.UnitTest
             [WpfFact]
             public void SwitchMode6()
             {
+                var command = "foo";
                 var mode = new Mock<ICommandMode>();
                 mode.SetupGet(x => x.ModeKind).Returns(ModeKind.Command);
-                mode.SetupGet(x => x.Command).Returns("foo");
+                mode.SetupGet(x => x.Command).Returns(command);
+                mode.SetupGet(x => x.EditableCommand).Returns(new EditableCommand(command));
                 _vimBuffer.CommandModeImpl = mode.Object;
                 _vimBuffer.RaiseSwitchedMode(_vimBuffer.CommandModeImpl);
                 Assert.Equal(":foo", _marginControl.CommandLineTextBox.Text);
@@ -435,8 +437,10 @@ namespace Vim.UI.Wpf.UnitTest
             [WpfFact]
             public void NoEvents2()
             {
+                var command = "foo";
                 var mode = new Mock<ICommandMode>();
-                mode.SetupGet(x => x.Command).Returns("foo");
+                mode.SetupGet(x => x.Command).Returns(command);
+                mode.SetupGet(x => x.EditableCommand).Returns(new EditableCommand(command));
                 mode.SetupGet(x => x.ModeKind).Returns(ModeKind.Command);
                 _vimBuffer.ModeKindImpl = ModeKind.Command;
                 _vimBuffer.ModeImpl = mode.Object;


### PR DESCRIPTION
#### Issues

- Closes #1103 
- Closes #2683

#### Discussion

This issue has been open since 2013! And it was surprisingly difficult to fix because of the complex interconnection of history, command mode, and the command margin. The main idea is that instead of passing around a string to represent an in-progress command, we need to supplement the text of the command with the current insertion point. As a result, there is a new structure called `EditableCommand` that combines text with a caret position. In addition to the `Left` operation, an editable command also now supports the related Vim keys `Home`, `End`, `Left`, `Right` and `Delete` which, of course, can also can be mapped.