### PR TITLE
Publish should only occur on master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,4 @@
 trigger:
-- dev/jaredpar/*
 - master
 
 pr:
@@ -87,5 +86,5 @@ jobs:
     inputs:
       filePath: Scripts\Build.ps1
       arguments: -ci -uploadVsix -config Release
-    condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
 


### PR DESCRIPTION
VSIX gallery publishing should only occur on builds in the master
branch.

Before this change publish was occuring whenever the build was
IndividualCI or BatchedCI. The CI term in Azure DevOps means a build
that occurs on merged code (not in PR). This meant every time DevOps was
triggered on merged code the result was published.

The initial intent was that only 'master' was setup to build on merge
but some developmental code got left in and it ended up triggering on
dev branches as well as master. This fixes both problems.