### PR TITLE
Fix UI delay in navigate to

### DIFF
--- a/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
+++ b/Src/VsVimShared/Implementation/Misc/StandardCommandTarget.cs
@@ -323,7 +323,7 @@ namespace Vim.VisualStudio.Implementation.Misc
                     // The GoToDefinition command will often cause a selection
                     // to occur in the  buffer.
                     {
-                        var handler = new UnwantedSelectionHandler(_vimBuffer.Vim, _textManager);
+                        var handler = new UnwantedSelectionHandler(_vimBuffer.Vim);
                         preAction = handler.PreAction;
                         postAction = handler.PostAction;
                     }
@@ -336,7 +336,7 @@ namespace Vim.VisualStudio.Implementation.Misc
                     // before the command was run (single line case).
                     if (_textView.Selection.IsEmpty)
                     {
-                        var handler = new UnwantedSelectionHandler(_vimBuffer.Vim, _textManager);
+                        var handler = new UnwantedSelectionHandler(_vimBuffer.Vim);
                         postAction = () => handler.ClearSelection(_textView);
                     }
                     return false;

--- a/Src/VsVimShared/Implementation/NavigateTo/NavigateToItemProviderFactory.cs
+++ b/Src/VsVimShared/Implementation/NavigateTo/NavigateToItemProviderFactory.cs
@@ -39,7 +39,7 @@ namespace Vim.VisualStudio.Implementation.NavigateTo
             _vim = vim;
             _textManager = textManager;
             _synchronizationContext = WindowsFormsSynchronizationContext.Current;
-            _unwantedSelectionHandler = new UnwantedSelectionHandler(_vim, _textManager);
+            _unwantedSelectionHandler = new UnwantedSelectionHandler(_vim);
         }
 
         private void OnSearchStarted(string searchText)


### PR DESCRIPTION
The `UnwantedSelectionHandler` is properly using the
`_VSRDTFLAGS4.RDT_PendingInitialization` when iterating the RDT for open
documents. It seems though that this flag is not respected for project
files and forces them to be realized by Visual Studio. Loading a project
file can be fairly expensive and this gets done synchronously when
begining a navigate to operation.

Long term this does seem like a bug that Visual Studio should look into.
Short term though the `UnwantedSelectionHandler` can avoid the RDT
entirely by just walking through `IVim.VimBuffers` instead. This
represents the active set of `IVimBuffer` instances and that is
where we want to control the selection before / after a
navigate to operation.

closes 2715