### PR TITLE
[VSMac] Fix rename refactoring by not using External Edit Monitoring.

### DIFF
--- a/Src/VimMac/CaretUtil.cs
+++ b/Src/VimMac/CaretUtil.cs
@@ -2,16 +2,26 @@
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
+using Vim.UI.Cocoa.Implementation.InlineRename;
 
 namespace Vim.Mac
 {
     [Export(typeof(IVimBufferCreationListener))]
     internal class CaretUtil : IVimBufferCreationListener
     {
+        private readonly InlineRenameListenerFactory _inlineRenameListenerFactory;
+
+        [ImportingConstructor]
+        public CaretUtil(InlineRenameListenerFactory inlineRenameListenerFactory)
+        {
+            _inlineRenameListenerFactory = inlineRenameListenerFactory;
+        }
+
+
         private void SetCaret(IVimBuffer vimBuffer)
         {
             var textView = vimBuffer.TextView;
-            if (vimBuffer.Mode.ModeKind == ModeKind.Insert || vimBuffer.Mode.ModeKind == ModeKind.ExternalEdit)
+            if (vimBuffer.Mode.ModeKind == ModeKind.Insert || _inlineRenameListenerFactory.InRename)
             {
                 //TODO: what's the minimum caret width for accessibility?
                 textView.Options.SetOptionValue(DefaultTextViewOptions.CaretWidthOptionName, 1.0);
@@ -34,6 +44,7 @@ namespace Vim.Mac
         {
             SetCaret(vimBuffer);
             vimBuffer.SwitchedMode += (_,__) => SetCaret(vimBuffer);
+            _inlineRenameListenerFactory.RenameUtil.IsRenameActiveChanged += (_, __) => SetCaret(vimBuffer);
         }
     }
 }

--- a/Src/VimMac/CaretUtil.cs
+++ b/Src/VimMac/CaretUtil.cs
@@ -21,6 +21,10 @@ namespace Vim.Mac
         private void SetCaret(IVimBuffer vimBuffer)
         {
             var textView = vimBuffer.TextView;
+
+            if (textView.IsClosed)
+                return;
+
             if (vimBuffer.Mode.ModeKind == ModeKind.Insert || _inlineRenameListenerFactory.InRename)
             {
                 //TODO: what's the minimum caret width for accessibility?

--- a/Src/VimMac/ShellWildcardSearchScope.cs
+++ b/Src/VimMac/ShellWildcardSearchScope.cs
@@ -3,17 +3,18 @@ using System.Collections.Immutable;
 using System.Linq;
 using MonoDevelop.Core;
 using MonoDevelop.Ide.FindInFiles;
+using Provider = MonoDevelop.Ide.FindInFiles.FileProvider;
 
 namespace Vim.Mac
 {
     internal class ShellWildcardSearchScope : Scope
     {
-        private ImmutableArray<FileProvider> files;
+        private ImmutableArray<Provider> files;
 
         public ShellWildcardSearchScope(string workingDirectory, string wildcard)
         {
             files = ShellWildcardExpansion.ExpandWildcard(wildcard, workingDirectory, enumerateDirectories: true)
-                        .Select(f => new FileProvider(f))
+                        .Select(f => new Provider(f))
                         .ToImmutableArray();
         }
 
@@ -22,7 +23,7 @@ namespace Vim.Mac
             return "Vim wildcard search scope";
         }
 
-        public override IEnumerable<FileProvider> GetFiles(ProgressMonitor monitor, FilterOptions filterOptions)
+        public override IEnumerable<Provider> GetFiles(ProgressMonitor monitor, FilterOptions filterOptions)
         {
             return files;
         }

--- a/Src/VimMac/VimApplicationSettings.cs
+++ b/Src/VimMac/VimApplicationSettings.cs
@@ -124,7 +124,7 @@ namespace Vim.VisualStudio.Implementation.Settings
 
         bool IVimApplicationSettings.EnableExternalEditMonitoring
         {
-            get { return GetBoolean(EnableExternalEditMonitoringName, defaultValue: true); }
+            get { return GetBoolean(EnableExternalEditMonitoringName, defaultValue: false); }
             set { SetBoolean(EnableExternalEditMonitoringName, value); }
         }
 


### PR DESCRIPTION
I don't fully understand why this works and didn't try to understand
either. It seems like we should just not use this setting on MacOS
(we don't have any 3rd party addins that can modify source code on Mac)

Fixes #2763