### PR TITLE
Remove buffer from VimBuffer list when TextView is closed

### DIFF
--- a/Src/VimCore/VimBuffer.fs
+++ b/Src/VimCore/VimBuffer.fs
@@ -246,6 +246,11 @@ type internal VimBuffer
         |> Observable.subscribe (fun args -> this.OnBeforeSave args.TextBuffer)
         |> _bag.Add
 
+        // Close the buffer when the TextView closes
+        _textView.Closed
+        |> Observable.subscribe (fun args -> this.Close())
+        |> _bag.Add
+
     member x.IsReadOnly
         with get() = _vim.VimHost.IsReadOnly _vimBufferData.TextBuffer
 

--- a/Src/VimMac/VimKeyProcessor.cs
+++ b/Src/VimMac/VimKeyProcessor.cs
@@ -79,10 +79,6 @@ namespace Vim.UI.Cocoa
                 {
                     handled = TryProcess(keyInput);
                 }
-                else
-                {
-                    handled = false;
-                }
             }
 
             VimTrace.TraceInfo("VimKeyProcessor::KeyDown Handled = {0}", handled);

--- a/Src/VsVimShared/HostFactory.cs
+++ b/Src/VsVimShared/HostFactory.cs
@@ -203,7 +203,6 @@ namespace Vim.VisualStudio
             var textView = vimBuffer.TextView;
             textView.Closed += (x, y) =>
             {
-                vimBuffer.Close();
                 _toSyncSet.Remove(vimBuffer);
                 _vimBufferToCommandTargetMap.Remove(vimBuffer);
             };

--- a/Test/VimCoreTest/MacroIntegrationTest.cs
+++ b/Test/VimCoreTest/MacroIntegrationTest.cs
@@ -77,11 +77,6 @@ namespace Vim.UnitTest
 
                 Create("hello world");
 
-                // Stand-in for HostFactory which calls IVimBuffer.Close in response to the associated ITextView.Closed.
-                // The root cause of the referenced issue was that MacroRecorder disposed its buffer event handlers on IVimBuffer.Close.
-                // Since IVimBuffer.Close is raised before the final IVimBuffer.KeyInputEnd is raised, the last keystroke failed to record.
-                _textView.Closed += (s, e) => _vimBuffer.Close();
-
                 _vimBuffer.Process("qaZQ");
                 Assert.True(_vimBuffer.IsClosed);
             

--- a/Test/VimCoreTest/VimBufferTest.cs
+++ b/Test/VimCoreTest/VimBufferTest.cs
@@ -1273,7 +1273,6 @@ namespace Vim.UnitTest
                 finally
                 {
                     altTextView.Close();
-                    altVimBuffer.Close();
                 }
             }
 
@@ -1303,7 +1302,6 @@ namespace Vim.UnitTest
                 finally
                 {
                     altTextView.Close();
-                    altVimBuffer.Close();
                 }
             }
         }


### PR DESCRIPTION
Remove buffer from VimBuffer list when TextView is closed

Fixes https://github.com/VsVim/VsVim/issues/2792https://github.com/VsVim/VsVim/issues/2792https://github.com/VsVim/VsVim/issues/2792
