### PR TITLE
Only allow Vim buffers to be created for the main editor.

### DIFF
--- a/Src/VimMac/Properties/AddinInfo.cs
+++ b/Src/VimMac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly: Addin(
     "VsVim",
     Namespace = "Vim.Mac",
-    Version = "2.8.0.5"
+    Version = "2.8.0.6"
 )]
 
 [assembly: AddinName("VsVim")]

--- a/Src/VimMac/VimHost.cs
+++ b/Src/VimMac/VimHost.cs
@@ -702,7 +702,7 @@ namespace Vim.Mac
 
         public bool ShouldCreateVimBuffer(ITextView textView)
         {
-            return !textView.TextBuffer.ContentType.IsDebuggerWindow();
+            return textView.Properties.ContainsProperty(typeof(MonoDevelop.Ide.Gui.Documents.DocumentController));
         }
 
         public bool ShouldIncludeRcFile(VimRcPath vimRcPath)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
       filePath: Scripts/build.sh
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: Binaries/Debug/VimMac/net472/Vim.Mac.VsVim_2.8.0.5.mpack
+      pathToPublish: Binaries/Debug/VimMac/net472/Vim.Mac.VsVim_2.8.0.6.mpack
       artifactName: VSMacExtension
 
 - job: VsVim_Build_Test


### PR DESCRIPTION
Instead of special casing the Debugger windows, exclude any text
view that isn't considered to be the main editor. This will allow
some future VSMac pads to function correctly.