### PR TITLE
Close signature help and completion window when escape is pressed

### DIFF
--- a/Src/VimMac/Properties/AddinInfo.cs
+++ b/Src/VimMac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly: Addin(
     "VsVim",
     Namespace = "Vim.Mac",
-    Version = "2.8.0.7"
+    Version = "2.8.0.8"
 )]
 
 [assembly: AddinName("VsVim")]

--- a/Src/VimMac/VimKeyProcessor.cs
+++ b/Src/VimMac/VimKeyProcessor.cs
@@ -129,7 +129,7 @@ namespace Vim.UI.Cocoa
             if (_completionBroker.IsCompletionActive(TextView) && !IsEscapeKey(e))
                 return false;
 
-            if (_signatureHelpBroker.IsSignatureHelpActive(TextView))
+            if (_signatureHelpBroker.IsSignatureHelpActive(TextView) && !IsEscapeKey(e))
                 return false;
 
             if (_inlineRenameListenerFactory.InRename)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
       filePath: Scripts/build.sh
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: Binaries/Debug/VimMac/net472/Vim.Mac.VsVim_2.8.0.7.mpack
+      pathToPublish: Binaries/Debug/VimMac/net472/Vim.Mac.VsVim_2.8.0.8.mpack
       artifactName: VSMacExtension
 
 - job: VsVim_Build_Test


### PR DESCRIPTION
When signature help was displayed and escape key was pressed, the
key was being handled by VSMac which didn't dismiss display windows.
Changed so that escape key is handled by Vim when signature help
is visible. This ensures that IDisplayWindowBroker.DismissDisplayWindows()
gets called.

Fixes #2766