### PR TITLE
(Mac) Change TryProcess(keyInput) to use VimBuffer.CanProcess

### DIFF
--- a/Src/VimMac/VimKeyProcessor.cs
+++ b/Src/VimMac/VimKeyProcessor.cs
@@ -101,7 +101,7 @@ namespace Vim.UI.Cocoa
         /// </summary>
         private bool TryProcess(KeyInput keyInput)
         {
-            return VimBuffer.CanProcessAsCommand(keyInput) && VimBuffer.Process(keyInput).IsAnyHandled;
+            return VimBuffer.CanProcess(keyInput) && VimBuffer.Process(keyInput).IsAnyHandled;
         }
 
         private bool KeyEventIsDeadChar(KeyEventArgs e)


### PR DESCRIPTION
I think the previous use of CanProcessAsCommand was to workaround the fact
that I couldn't previously prevent keys from being handled in VSMac 8.3.

This (hack) meant that VSVim wasn't handling many Insert mode keypresses which
meant that Insert mode key remaps and Insert mode macro recordings weren't
working.

Fixes https://github.com/VsVim/VsVim/issues/2807
Fixes https://github.com/VsVim/VsVim/issues/2820