### PR TITLE
Change `:make` to build project only

### DIFF
--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -1592,7 +1592,7 @@ type VimInterpreter
 
     /// Run the host make command 
     member x.RunMake hasBang arguments = 
-        _vimHost.Make (not hasBang) arguments 
+        _vimHost.Make (hasBang) arguments 
 
     /// Run the map keys command
     member x.RunMapKeys leftKeyNotation rightKeyNotation keyRemapModes allowRemap mapArgumentList =

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -960,9 +960,16 @@ namespace Vim.VisualStudio
             return null;
         }
 
-        public override void Make(bool jumpToFirstError, string arguments)
+        public override void Make(bool buildSolution, string arguments)
         {
-            SafeExecuteCommand(null, "Build.BuildSolution");
+            if (buildSolution)
+            {
+                SafeExecuteCommand(null, "Build.BuildSolution");
+            }
+            else
+            {
+                SafeExecuteCommand(null, "Build.BuildOnlyProject");
+            }
         }
 
         public override bool TryGetFocusedTextView(out ITextView textView)


### PR DESCRIPTION
This change supports native visual studio behavior of building
the current project only (and not the whole solution)
when `:make` or `:mak` is invoked.

When a shebang (`!`) is appended to the command i.e. `:make!`,
a full solution build is triggered.