### PR TITLE
Support 'set fileformat' and 'set fileformats'

### DIFF
--- a/Src/VimCore/VimSettings.fs
+++ b/Src/VimCore/VimSettings.fs
@@ -537,6 +537,9 @@ type internal LocalSettings
         _globalSettings: IVimGlobalSettings
     ) =
 
+    //TODO Also support global FileFormats setting, in addition to local FileFormat setting,
+    //which is only per buffer
+    //TODO Select default FileFormat and FileFormats values based on current OS
     static let LocalSettingInfoList =
         [|
             (AutoIndentName, "ai", SettingValue.Toggle false, SettingOptions.None)
@@ -554,6 +557,7 @@ type internal LocalSettings
             (SoftTabStopName, "sts", SettingValue.Number 0, SettingOptions.None)
             (TabStopName, "ts", SettingValue.Number 8, SettingOptions.None)
             (TextWidthName, "tw", SettingValue.Number 0, SettingOptions.None)
+            (FileFormatName, "ff", SettingValue.String "dos", SettingOptions.None)
         |]
 
     static let LocalSettingList = 
@@ -667,6 +671,9 @@ type internal LocalSettings
         member x.TextWidth
             with get() = _map.GetNumberValue TextWidthName
             and set value = _map.TrySetValue TextWidthName (SettingValue.Number value) |> ignore
+        member x.FileFormat
+            with get() = _map.GetStringValue FileFormatName
+            and set value = _map.TrySetValue FileFormatName (SettingValue.String value) |> ignore
 
         member x.IsNumberFormatSupported numberFormat = x.IsNumberFormatSupported numberFormat
 

--- a/Src/VimCore/VimSettingsInterface.fs
+++ b/Src/VimCore/VimSettingsInterface.fs
@@ -75,6 +75,7 @@ module LocalSettingNames =
     let CommentsName = "comments"
     let IsKeywordName = "iskeyword"
     let IsIdentName = "isident"
+    let FileFormatName = "fileformat"
 
 module WindowSettingNames =
 
@@ -619,6 +620,9 @@ and IVimLocalSettings =
 
     /// Is the provided NumberFormat supported by the current options
     abstract IsNumberFormatSupported: NumberFormat -> bool
+
+    /// Which fileformat to convert the file to: unix, dos, mac
+    abstract FileFormat: string with get, set
 
     inherit IVimSettings
 


### PR DESCRIPTION
This PR aims to implement `set fileformat` and `set fileformats`, as requested in #2663.

`fileformat` allows the user to set the file format per file, while `fileformats` allows the user to set the file format for every file.

TODO:
- [x] Add `set fileformat` setting
- [ ] Add `set fileformats` setting
- [ ] Set defaults based on current OS
- [ ] Set file format on save

Close #2663