### PR TITLE
Fixed ctrl-click to peek

### DIFF
--- a/Src/VimApp/VimAppHost.cs
+++ b/Src/VimApp/VimAppHost.cs
@@ -119,6 +119,11 @@ namespace VimApp
             return false;
         }
 
+        public override bool PeekDefinition()
+        {
+            return false;
+        }
+
         public override bool GoToGlobalDeclaration(ITextView textView, string name)
         {
             return false;

--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1487,10 +1487,20 @@ type internal CommandUtil
 
         CommandResult.Completed ModeSwitch.NoSwitch
 
+    /// Peek at the definition of the word under the caret
+    member x.PeekDefinition () =
+        match _commonOperations.PeekDefinition() with
+        | Result.Succeeded -> ()
+        | Result.Failed(msg) -> _statusUtil.OnError msg
+
+        CommandResult.Completed ModeSwitch.NoSwitch
+
     /// Go to the definition of the word under the mouse
     member x.GoToDefinitionUnderMouse () =
         if x.MoveCaretToMouseUnconditionally() then
-            x.GoToDefinition()
+            match EditorOptionsUtil.GetOptionValue _options EditorOptionsUtil.ClickGoToDefOpensPeekId with
+                | Some true -> x.PeekDefinition()
+                | _ -> x.GoToDefinition()
         else
             CommandResult.Error
 

--- a/Src/VimCore/CommonOperations.fs
+++ b/Src/VimCore/CommonOperations.fs
@@ -1243,6 +1243,22 @@ type internal CommonOperations
             else
                 Result.Failed(Resources.Common_GotoDefFailed word)
 
+    member x.PeekDefinition() =
+        match x.WordUnderCursorOrEmpty with
+        | "" ->
+            Result.Failed(Resources.Common_GotoDefNoWordUnderCursor) 
+        | word when x.IsLink word ->
+            x.OpenLinkUnderCaret()
+        | word when x.IsVimLink word ->
+            x.OpenVimLinkUnderCaret()
+        | word ->
+            let before = TextViewUtil.GetCaretVirtualPoint _textView
+            if _vimHost.PeekDefinition() then
+                _jumpList.Add before
+                Result.Succeeded
+            else
+                Result.Failed(Resources.Common_GotoDefFailed word)
+
     member x.GoToLocalDeclaration() = 
         let caretPoint = x.CaretVirtualPoint
         if _vimHost.GoToLocalDeclaration _textView x.WordUnderCursorOrEmpty then
@@ -2881,6 +2897,7 @@ type internal CommonOperations
         member x.GoToFileInNewWindow() = x.GoToFileInNewWindow()
         member x.GoToFileInNewWindow name = x.GoToFileInNewWindow name
         member x.GoToDefinition() = x.GoToDefinition()
+        member x.PeekDefinition() = x.PeekDefinition()
         member x.GoToNextTab direction count = x.GoToNextTab direction count
         member x.GoToTab index = x.GoToTab index
         member x.GoToTagInNewWindow folder ident = x.GoToTagInNewWindow folder ident

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -5180,6 +5180,9 @@ type IVimHost =
     /// Go to the definition of the value under the cursor
     abstract GoToDefinition: unit -> bool
 
+    /// Peek at the definition of the value under the cursor
+    abstract PeekDefinition: unit -> bool
+
     /// Go to the local declaration of the value under the cursor
     abstract GoToLocalDeclaration: textView: ITextView -> identifier: string -> bool
 

--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -2895,6 +2895,10 @@ type MoveCaretFlags =
     | All = 0xffffffff
 
 module EditorOptionsUtil =
+    /// The option for peeking when clicking to go to a definition.
+    /// From Microsoft.VisualStudio.Text.EditorDefaultWpfViewOptions.ClickGoToDefOpensPeekId
+    /// This was introduced in v15, so recreating so we don't need to drop v14.
+    let public ClickGoToDefOpensPeekId = new EditorOptionKey<bool>("TextView/ClickGoToDefOpensPeek")
 
     /// Get the option value if it exists
     let GetOptionValue (opts: IEditorOptions) (key: EditorOptionKey<'a>) =

--- a/Src/VimCore/MefInterfaces.fs
+++ b/Src/VimCore/MefInterfaces.fs
@@ -423,6 +423,10 @@ type ICommonOperations =
     /// be generated as appropriate
     abstract GoToDefinition: unit -> Result
 
+    /// Attempt to PeekDefinition on the current state of the buffer.  If this operation fails, an error message will
+    /// be generated as appropriate
+    abstract PeekDefinition: unit -> Result
+
     /// Go to the file named in the word under the cursor
     abstract GoToFile: unit -> unit
 

--- a/Src/VimMac/VimHost.cs
+++ b/Src/VimMac/VimHost.cs
@@ -350,6 +350,11 @@ namespace Vim.Mac
             return Dispatch(CommandNameGoToDefinition);
         }
 
+        public bool PeekDefinition()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool GoToGlobalDeclaration(ITextView textView, string identifier)
         {
             return Dispatch(CommandNameGoToDefinition);

--- a/Src/VimTestUtils/Mock/MockVimHost.cs
+++ b/Src/VimTestUtils/Mock/MockVimHost.cs
@@ -33,6 +33,7 @@ namespace Vim.UnitTest.Mock
         public bool ClosedOtherTabs { get; private set; }
         public Action<string, bool, string, VimGrepFlags, FSharpFunc<Unit, Unit>> FindInFilesFunc { get; set; }
         public int GoToDefinitionCount { get; set; }
+        public int PeekDefinitionCount { get; set; }
         public bool GoToFileReturn { get; set; }
         public bool GoToDefinitionReturn { get; set; }
         public Func<ITextView, ITextSnapshotLine, ITextSnapshotLine, IVimLocalSettings, FSharpOption<int>> GetNewLineIndentFunc { get; set; }
@@ -103,6 +104,7 @@ namespace Vim.UnitTest.Mock
             FocusedTextView = null;
             GetNewLineIndentFunc = delegate { return FSharpOption<int>.None; };
             GoToDefinitionCount = 0;
+            PeekDefinitionCount = 0;
             GoToDefinitionReturn = true;
             GoToGlobalDeclarationFunc = delegate { throw new NotImplementedException(); };
             GoToLocalDeclarationFunc = delegate { throw new NotImplementedException(); };
@@ -145,6 +147,12 @@ namespace Vim.UnitTest.Mock
         bool IVimHost.GoToDefinition()
         {
             GoToDefinitionCount++;
+            return GoToDefinitionReturn;
+        }
+
+        bool IVimHost.PeekDefinition()
+        {
+            PeekDefinitionCount++;
             return GoToDefinitionReturn;
         }
 

--- a/Src/VimTestUtils/VimTestBase.cs
+++ b/Src/VimTestUtils/VimTestBase.cs
@@ -596,6 +596,13 @@ namespace Vim.UnitTest
             host.HostControl.UpdateLayout();
         }
 
+        protected void SetVs2017AndAboveEditorOptionValue<T>(IEditorOptions options, EditorOptionKey<T> key, T value)
+        {
+#if !VS_SPECIFIC_2015
+            options.SetOptionValue(key, value);
+#endif
+        }
+
         /// <summary>
         /// This must be public static for xunit to pick it up as a Theory data source
         /// </summary>

--- a/Src/VimTestUtils/WpfFactAttribute.cs
+++ b/Src/VimTestUtils/WpfFactAttribute.cs
@@ -31,6 +31,20 @@ namespace Vim.UnitTest
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     [XunitTestCaseDiscoverer("Vim.UnitTest.Utilities.WpfFactDiscoverer", "Vim.UnitTest.Utils")]
+    public class Vs2017AndAboveWpfFactAttribute : WpfFactAttribute
+    {
+        public override string Skip =>
+#if VS_SPECIFIC_2015
+            $"Test only supported in VS 2017 and above";
+#else
+            null;
+#endif
+
+        public Vs2017AndAboveWpfFactAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("Vim.UnitTest.Utilities.WpfFactDiscoverer", "Vim.UnitTest.Utils")]
     public class AsyncCompletionWpfFactAttribute : WpfFactAttribute
     {
         public override string Skip => VimSpecificUtil.HasAsyncCompletion

--- a/Src/VimWpf/VimHost.cs
+++ b/Src/VimWpf/VimHost.cs
@@ -188,6 +188,8 @@ namespace Vim.UI.Wpf
 
         public abstract bool GoToDefinition();
 
+        public abstract bool PeekDefinition();
+
         public abstract bool GoToGlobalDeclaration(ITextView textView, string name);
 
         public abstract bool GoToLocalDeclaration(ITextView textView, string name);

--- a/Src/VsVimShared/VsVimHost.cs
+++ b/Src/VsVimShared/VsVimHost.cs
@@ -235,6 +235,7 @@ namespace Vim.VisualStudio
         #endregion
 
         internal const string CommandNameGoToDefinition = "Edit.GoToDefinition";
+        internal const string CommandNamePeekDefinition = "Edit.PeekDefinition";
         internal const string CommandNameGoToDeclaration = "Edit.GoToDeclaration";
 
         private readonly IVsAdapter _vsAdapter;
@@ -536,6 +537,11 @@ namespace Vim.VisualStudio
         public override bool GoToDefinition()
         {
             return SafeExecuteCommand(_textManager.ActiveTextViewOptional, CommandNameGoToDefinition);
+        }
+
+        public override bool PeekDefinition()
+        {
+            return SafeExecuteCommand(_textManager.ActiveTextViewOptional, CommandNamePeekDefinition);
         }
 
         /// <summary>

--- a/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
+++ b/Test/VimCoreTest/CommonOperationsIntegrationTest.cs
@@ -1220,6 +1220,7 @@ namespace Vim.UnitTest
             public void GoToDefinition1()
             {
                 Create("foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 var res = _commonOperations.GoToDefinition();
                 Assert.True(res.IsSucceeded);
                 Assert.Equal(1, VimHost.GoToDefinitionCount);
@@ -1230,6 +1231,7 @@ namespace Vim.UnitTest
             public void GoToDefinition2()
             {
                 Create("foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 VimHost.GoToDefinitionReturn = false;
                 var res = _commonOperations.GoToDefinition();
                 Assert.True(res.IsFailed);
@@ -1243,6 +1245,7 @@ namespace Vim.UnitTest
             public void GoToDefinition3()
             {
                 Create("      foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 VimHost.GoToDefinitionReturn = false;
                 var res = _commonOperations.GoToDefinition();
                 Assert.True(res.IsFailed);
@@ -1252,6 +1255,7 @@ namespace Vim.UnitTest
             public void GoToDefinition4()
             {
                 Create("  foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 VimHost.GoToDefinitionReturn = false;
                 var res = _commonOperations.GoToDefinition();
                 Assert.True(res.IsFailed);
@@ -1262,8 +1266,66 @@ namespace Vim.UnitTest
             public void GoToDefinition5()
             {
                 Create("foo bar baz");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 VimHost.GoToDefinitionReturn = false;
                 var res = _commonOperations.GoToDefinition();
+                Assert.True(res.IsFailed);
+                Assert.Equal(Resources.Common_GotoDefFailed("foo"), res.AsFailed().Error);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void PeekDefinition1()
+            {
+                Create("foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                var res = _commonOperations.PeekDefinition();
+                Assert.True(res.IsSucceeded);
+                Assert.Equal(1, VimHost.PeekDefinitionCount);
+                Assert.Equal(_textView.GetCaretVirtualPoint(), _vimBuffer.JumpList.LastJumpLocation.Value);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void PeekDefinition2()
+            {
+                Create("foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                VimHost.GoToDefinitionReturn = false;
+                var res = _commonOperations.PeekDefinition();
+                Assert.True(res.IsFailed);
+                Assert.Contains("foo", ((Result.Failed)res).Error);
+            }
+
+            /// <summary>
+            /// Make sure we don't crash when nothing is under the cursor
+            /// </summary>
+            [Vs2017AndAboveWpfFact]
+            public void PeekDefinition3()
+            {
+                Create("      foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                VimHost.GoToDefinitionReturn = false;
+                var res = _commonOperations.PeekDefinition();
+                Assert.True(res.IsFailed);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void PeekDefinition4()
+            {
+                Create("  foo");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                VimHost.GoToDefinitionReturn = false;
+                var res = _commonOperations.PeekDefinition();
+                Assert.True(res.IsFailed);
+                Assert.Equal(Resources.Common_GotoDefNoWordUnderCursor, res.AsFailed().Error);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void PeekDefinition5()
+            {
+                Create("foo bar baz");
+                SetVs2017AndAboveEditorOptionValue(_commonOperations.EditorOptions, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                VimHost.GoToDefinitionReturn = false;
+                var res = _commonOperations.PeekDefinition();
                 Assert.True(res.IsFailed);
                 Assert.Equal(Resources.Common_GotoDefFailed("foo"), res.AsFailed().Error);
             }

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -214,12 +214,28 @@ namespace Vim.UnitTest
             public void ControlClick()
             {
                 Create("cat dog bear", "");
+                SetVs2017AndAboveEditorOptionValue(_textView.Options, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 _textView.SetVisibleLineCount(2);
                 var point = _textView.GetPointInLine(0, 5); // 'o' in 'dog'
                 _testableMouseDevice.Point = point;
                 _vimBuffer.ProcessNotation("<C-LeftMouse>");
                 Assert.Equal(5, _textView.GetCaretPoint().Position); // 'o' in 'dog'
                 Assert.Equal(1, _vimHost.GoToDefinitionCount);
+                Assert.Equal(0, _vimHost.PeekDefinitionCount);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void ControlClickPeek()
+            {
+                Create("cat dog bear", "");
+                SetVs2017AndAboveEditorOptionValue(_textView.Options, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                _textView.SetVisibleLineCount(2);
+                var point = _textView.GetPointInLine(0, 5); // 'o' in 'dog'
+                _testableMouseDevice.Point = point;
+                _vimBuffer.ProcessNotation("<C-LeftMouse>");
+                Assert.Equal(5, _textView.GetCaretPoint().Position); // 'o' in 'dog'
+                Assert.Equal(0, _vimHost.GoToDefinitionCount);
+                Assert.Equal(1, _vimHost.PeekDefinitionCount);
             }
         }
 
@@ -9659,6 +9675,7 @@ namespace Vim.UnitTest
             public void GoToLinkWithMouse()
             {
                 Create("foo https://github.com/VsVim/VsVim bar", "");
+                SetVs2017AndAboveEditorOptionValue(_textView.Options, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 var point = _textView.GetPointInLine(0, 8);
                 var link = "";
                 _vimHost.OpenLinkFunc = arg =>
@@ -9671,6 +9688,27 @@ namespace Vim.UnitTest
                 Assert.Equal("https://github.com/VsVim/VsVim", link);
                 Assert.Equal(point, _textView.GetCaretPoint());
                 Assert.Equal(0, _vimHost.GoToDefinitionCount);
+                Assert.Equal(0, _vimHost.PeekDefinitionCount);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void GoToLinkWithMousePeek()
+            {
+                Create("foo https://github.com/VsVim/VsVim bar", "");
+                SetVs2017AndAboveEditorOptionValue(_textView.Options, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                var point = _textView.GetPointInLine(0, 8);
+                var link = "";
+                _vimHost.OpenLinkFunc = arg =>
+                {
+                    link = arg;
+                    return true;
+                };
+                _testableMouseDevice.Point = point;
+                _vimBuffer.ProcessNotation("<C-LeftMouse>");
+                Assert.Equal("https://github.com/VsVim/VsVim", link);
+                Assert.Equal(point, _textView.GetCaretPoint());
+                Assert.Equal(0, _vimHost.GoToDefinitionCount);
+                Assert.Equal(0, _vimHost.PeekDefinitionCount);
             }
 
             [WpfFact]

--- a/Test/VimWpfTest/VimHostTests.cs
+++ b/Test/VimWpfTest/VimHostTests.cs
@@ -57,6 +57,11 @@ namespace Vim.UI.Wpf.UnitTest
                 throw new NotImplementedException();
             }
 
+            public override bool PeekDefinition()
+            {
+                throw new NotImplementedException();
+            }
+
             public override bool GoToGlobalDeclaration(ITextView textView, string name)
             {
                 throw new NotImplementedException();

--- a/Test/VimWpfTest/VimMouseProcessorTest.cs
+++ b/Test/VimWpfTest/VimMouseProcessorTest.cs
@@ -43,12 +43,27 @@ namespace Vim.UI.Wpf.UnitTest
             [WpfFact]
             public void GoToDefinition()
             {
+                SetVs2017AndAboveEditorOptionValue(_textView.Options, EditorOptionsUtil.ClickGoToDefOpensPeekId, false);
                 _keyboardDevice.SetupGet(x => x.KeyModifiers).Returns(VimKeyModifiers.Control);
                 var point = _textView.GetPointInLine(0, 0);
                 _testableMouseDevice.Point = point;
                 VimHost.GoToDefinitionReturn = false;
                 _vimMouseProcessor.TryProcess(VimKey.LeftMouse);
                 Assert.Equal(1, VimHost.GoToDefinitionCount);
+                Assert.Equal(0, VimHost.PeekDefinitionCount);
+            }
+
+            [Vs2017AndAboveWpfFact]
+            public void PeekDefinition()
+            {
+                SetVs2017AndAboveEditorOptionValue(_textView.Options, EditorOptionsUtil.ClickGoToDefOpensPeekId, true);
+                _keyboardDevice.SetupGet(x => x.KeyModifiers).Returns(VimKeyModifiers.Control);
+                var point = _textView.GetPointInLine(0, 0);
+                _testableMouseDevice.Point = point;
+                VimHost.GoToDefinitionReturn = false;
+                _vimMouseProcessor.TryProcess(VimKey.LeftMouse);
+                Assert.Equal(0, VimHost.GoToDefinitionCount);
+                Assert.Equal(1, VimHost.PeekDefinitionCount);
             }
 
             [WpfFact]


### PR DESCRIPTION
Fixes #2780

Check if user has the 'ClickGoToDefOpensPeek' option enabled, and if so, run Peek Definition instead of Go To Definition.
Add unit tests/adjust existing to check for this setting.

Please note that this is my first time working with both F# and VS extension development--so let me know if I'm doing something that isn't idiomatic or could be improved!