### PR TITLE
Move to a flat shared project structure

### DIFF
--- a/References/Vs2017/Vs2017.Build.targets
+++ b/References/Vs2017/Vs2017.Build.targets
@@ -1,7 +1,5 @@
 <Project>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" Condition="'$(VsVimProjectType)' == 'EditorHost'" />
-
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_2017</DefineConstants>
     <DefineConstants Condition="'$(VsVimProjectType)' == 'EditorHost'">$(DefineConstants);VIM_SPECIFIC_TEST_HOST</DefineConstants>

--- a/References/Vs2019/Vs2019.Build.targets
+++ b/References/Vs2019/Vs2019.Build.targets
@@ -1,7 +1,5 @@
 <Project>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" Condition="'$(VsVimProjectType)' == 'EditorHost'" />
-
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_2019</DefineConstants>
     <DefineConstants Condition="'$(VsVimProjectType)' == 'EditorHost'">$(DefineConstants);VIM_SPECIFIC_TEST_HOST</DefineConstants>

--- a/References/Vs2022/Vs2022.Build.targets
+++ b/References/Vs2022/Vs2022.Build.targets
@@ -1,7 +1,5 @@
 <Project>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" Condition="'$(VsVimProjectType)' == 'EditorHost'" />
-
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_2022</DefineConstants>
     <DefineConstants Condition="'$(VsVimProjectType)' == 'EditorHost'">$(DefineConstants);VIM_SPECIFIC_TEST_HOST</DefineConstants>

--- a/Src/VimApp/VimApp.csproj
+++ b/Src/VimApp/VimApp.csproj
@@ -38,4 +38,5 @@
     </Reference>
   </ItemGroup>
   <Import Project="..\VimWpf\VimWpf.projitems" Label="Shared" />
+  <Import Project="..\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
 </Project>

--- a/Test/VimCoreTest2017/VimCoreTest2017.csproj
+++ b/Test/VimCoreTest2017/VimCoreTest2017.csproj
@@ -38,5 +38,6 @@
     <ProjectReference Include="..\..\Src\VimTestUtils\VimTestUtils.csproj" />
   </ItemGroup>
   <Import Project="..\..\Src\VimWpf\VimWpf.projitems" Label="Shared" />
+  <Import Project="..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
   <Import Project="..\VimCoreTest\VimCoreTest.projitems" Label="Shared" />
 </Project>

--- a/Test/VimCoreTest2019/VimCoreTest2019.csproj
+++ b/Test/VimCoreTest2019/VimCoreTest2019.csproj
@@ -38,5 +38,6 @@
     <ProjectReference Include="..\..\Src\VimTestUtils\VimTestUtils.csproj" />
   </ItemGroup>
   <Import Project="..\..\Src\VimWpf\VimWpf.projitems" Label="Shared" />
+  <Import Project="..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
   <Import Project="..\VimCoreTest\VimCoreTest.projitems" Label="Shared" />
 </Project>

--- a/Test/VimCoreTest2022/VimCoreTest2022.csproj
+++ b/Test/VimCoreTest2022/VimCoreTest2022.csproj
@@ -36,5 +36,6 @@
     <ProjectReference Include="..\..\Src\VimTestUtils\VimTestUtils.csproj" />
   </ItemGroup>
   <Import Project="..\..\Src\VimWpf\VimWpf.projitems" Label="Shared" />
+  <Import Project="..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
   <Import Project="..\VimCoreTest\VimCoreTest.projitems" Label="Shared" />
 </Project>

--- a/Test/VsVimTest2017/VsVimTest2017.csproj
+++ b/Test/VsVimTest2017/VsVimTest2017.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\Src\VimTestUtils\VimTestUtils.csproj" />
     <ProjectReference Include="..\..\Src\VsVim2017\VsVim2017.csproj" />
   </ItemGroup>
+  <Import Project="..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
   <Import Project="..\VsVimSharedTest\VsVimSharedTest.projitems" Label="Shared" />
   <Import Project="..\VimWpfTest\VimWpfTest.projitems" Label="Shared" />
 </Project>

--- a/Test/VsVimTest2019/VsVimTest2019.csproj
+++ b/Test/VsVimTest2019/VsVimTest2019.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\..\Src\VimTestUtils\VimTestUtils.csproj" />
     <ProjectReference Include="..\..\Src\VsVim2019\VsVim2019.csproj" />
   </ItemGroup>
+  <Import Project="..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
   <Import Project="..\VsVimSharedTest\VsVimSharedTest.projitems" Label="Shared" />
   <Import Project="..\VimWpfTest\VimWpfTest.projitems" Label="Shared" />
 </Project>

--- a/Test/VsVimTest2022/VsVimTest2022.csproj
+++ b/Test/VsVimTest2022/VsVimTest2022.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\Src\VimTestUtils\VimTestUtils.csproj" />
     <ProjectReference Include="..\..\Src\VsVim2022\VsVim2022.csproj" />
   </ItemGroup>
-  <Import Project="..\VsVimSharedTest\VsVimSharedTest.projitems" Label="Shared" />
+  <Import Project="..\..\Src\VimEditorHost\VimEditorHost.projitems" Label="Shared" />
+  <Import Project="..\VsVimSharedTest\VsVimSharedTest.projitems" Label="Share" />
   <Import Project="..\VimWpfTest\VimWpfTest.projitems" Label="Shared" />
 </Project>

--- a/VsVim.sln
+++ b/VsVim.sln
@@ -68,8 +68,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VsVimTest2022", "Test\VsVim
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Src\VimEditorHost\VimEditorHost.projitems*{0751ffc7-8dba-4dbb-bcf6-ae29f4045b29}*SharedItemsImports = 5
 		Test\VimWpfTest\VimWpfTest.projitems*{0751ffc7-8dba-4dbb-bcf6-ae29f4045b29}*SharedItemsImports = 5
-		Test\VsVimSharedTest\VsVimSharedTest.projitems*{0751ffc7-8dba-4dbb-bcf6-ae29f4045b29}*SharedItemsImports = 5
 		Test\VimCoreTest\VimCoreTest.projitems*{1746bb8d-387d-40ab-a9f9-084a7a0676ea}*SharedItemsImports = 13
 		Src\VimWpf\VimWpf.projitems*{1aacc1ac-a8c6-4281-a080-91a4a3c5f21d}*SharedItemsImports = 5
 		Src\VsVimShared\VsVimShared.projitems*{1aacc1ac-a8c6-4281-a080-91a4a3c5f21d}*SharedItemsImports = 5
@@ -79,18 +79,24 @@ Global
 		Test\VsVimSharedTest\VsVimSharedTest.projitems*{5f7f6c25-d91c-4143-ac7d-df29a0a831ef}*SharedItemsImports = 13
 		Src\VimWpf\VimWpf.projitems*{648972d9-1a17-46d8-80c6-6810c5b8b4ae}*SharedItemsImports = 13
 		Src\VsVimShared\VsVimShared.projitems*{6dbed15c-fc2c-46e9-914d-685518573f0d}*SharedItemsImports = 13
+		Src\VimEditorHost\VimEditorHost.projitems*{7882df47-5dd7-4bc3-b559-0a5c0ff10b6a}*SharedItemsImports = 5
 		Src\VimWpf\VimWpf.projitems*{7882df47-5dd7-4bc3-b559-0a5c0ff10b6a}*SharedItemsImports = 5
 		Test\VimCoreTest\VimCoreTest.projitems*{7882df47-5dd7-4bc3-b559-0a5c0ff10b6a}*SharedItemsImports = 5
+		Src\VimEditorHost\VimEditorHost.projitems*{8db1c327-21a1-448b-a7a1-23eef6baa785}*SharedItemsImports = 5
 		Src\VimWpf\VimWpf.projitems*{8db1c327-21a1-448b-a7a1-23eef6baa785}*SharedItemsImports = 5
 		Test\VimWpfTest\VimWpfTest.projitems*{a24506e5-0602-4472-94d2-fb02772438a6}*SharedItemsImports = 13
+		Src\VimEditorHost\VimEditorHost.projitems*{cdc4a709-78ab-4c1f-949e-39870f9657ec}*SharedItemsImports = 5
 		Src\VimWpf\VimWpf.projitems*{cdc4a709-78ab-4c1f-949e-39870f9657ec}*SharedItemsImports = 5
 		Test\VimCoreTest\VimCoreTest.projitems*{cdc4a709-78ab-4c1f-949e-39870f9657ec}*SharedItemsImports = 5
+		Src\VimEditorHost\VimEditorHost.projitems*{d4e5690f-7d39-4429-8786-d135daec7bfe}*SharedItemsImports = 5
 		Src\VimWpf\VimWpf.projitems*{d4e5690f-7d39-4429-8786-d135daec7bfe}*SharedItemsImports = 5
 		Test\VimCoreTest\VimCoreTest.projitems*{d4e5690f-7d39-4429-8786-d135daec7bfe}*SharedItemsImports = 5
 		Src\VimWpf\VimWpf.projitems*{e6552def-32c8-407c-9940-52a2cc54e521}*SharedItemsImports = 5
 		Src\VsVimShared\VsVimShared.projitems*{e6552def-32c8-407c-9940-52a2cc54e521}*SharedItemsImports = 5
+		Src\VimEditorHost\VimEditorHost.projitems*{e9fb3820-5279-4489-b9c7-6fdbf44f07f2}*SharedItemsImports = 5
 		Test\VimWpfTest\VimWpfTest.projitems*{e9fb3820-5279-4489-b9c7-6fdbf44f07f2}*SharedItemsImports = 5
 		Test\VsVimSharedTest\VsVimSharedTest.projitems*{e9fb3820-5279-4489-b9c7-6fdbf44f07f2}*SharedItemsImports = 5
+		Src\VimEditorHost\VimEditorHost.projitems*{ff0ee51e-bf6d-4a81-a5d3-7ef572f68303}*SharedItemsImports = 5
 		Test\VimWpfTest\VimWpfTest.projitems*{ff0ee51e-bf6d-4a81-a5d3-7ef572f68303}*SharedItemsImports = 5
 		Test\VsVimSharedTest\VsVimSharedTest.projitems*{ff0ee51e-bf6d-4a81-a5d3-7ef572f68303}*SharedItemsImports = 5
 	EndGlobalSection


### PR DESCRIPTION
The VS team was able to identify the root problem here. The shared
project system expects to essentially see a flat list of projects where
as VsVim had added indirection through various target files. This is a
bug but it also has a very easy work around on the VsVim side: just
flatten the shared project hierarchy.

Tried this on my local machine with VS 2022 and was able to use the nav
bar just fine.

- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1358472
- https://github.com/dotnet/project-system/issues/7399