### PR TITLE
Add base directory to search path for csx/csxe

### DIFF
--- a/Src/VsVimShared/Implementation/CSharpScript/CSharpScriptExecutor.cs
+++ b/Src/VsVimShared/Implementation/CSharpScript/CSharpScriptExecutor.cs
@@ -56,6 +56,7 @@ namespace Vim.VisualStudio.Implementation.CSharpScript
 
             var searchPaths = new string[]
             {
+                baseDirectory,
                 Path.Combine(baseDirectory, "PublicAssemblies"),
                 Path.Combine(baseDirectory, "PrivateAssemblies"),
                 Path.Combine(baseDirectory, @"CommonExtensions\Microsoft\Editor"),


### PR DESCRIPTION
This allows referencing assemblies outside of `PublicAssemblies/PrivateAssemblies`.

For example, this allows referencing `Microsoft.VisualStudio.ExtensionEngine.dll` when dealing with extension manager stuff, like retrieving a list of installed extensions.