### PR TITLE
[VSMac] Switch macOS build to net6

### DIFF
--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -17,7 +17,13 @@ rm -rf ~/Library/Application\ Support/VisualStudio
 echo "Installing VSMac 17.0 Preview"
 ditto -rsrc "/Volumes/Visual Studio for Mac Preview Installer/" /Applications/
 
+echo "Installing dotnet 6.0.1xx"
+wget https://dot.net/v1/dotnet-install.sh
+bash dotnet-install.sh --channel 6.0.1xx
+
+echo "Building the extension"
 dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore /t:Build
 
+echo "Creating and installing Extension"
 # Generate mpack extension artifact
 dotnet msbuild Src/VimMac/VimMac.csproj /t:InstallAddin

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,7 +1,7 @@
 echo "Downloading VSMac"
 wget --quiet https://download.visualstudio.microsoft.com/download/pr/40d0790a-f7b7-44d3-a6e5-9bc5677fb1d7/28697450215d02cbec72e943d988f51f/visualstudioformacpreviewinstaller-17.0.0.149.dmg
 
-sudo hdiutil attach visualstudioformac-17.0.0.149.dmg
+sudo hdiutil attach visualstudioformacpreviewinstaller-17.0.0.149.dmg
 
 echo "Removing pre-installed VSMac"
 sudo rm -rf "/Applications/Visual Studio.app"
@@ -20,4 +20,4 @@ ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
 dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore /t:Build
 
 # Generate Vim.Mac.VsVim_2.8.0.0.mpack extension artifact
-msbuild Src/VimMac/VimMac.csproj /t:InstallAddin
+dotnet msbuild Src/VimMac/VimMac.csproj /t:InstallAddin

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -19,8 +19,10 @@ wget https://dot.net/v1/dotnet-install.sh
 bash dotnet-install.sh --channel 6.0.1xx
 
 echo "Building the extension"
-dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore /t:Build
+dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore
+cd Src/VimMac
+dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Build
 
 echo "Creating and installing Extension"
 # Generate mpack extension artifact
-dotnet msbuild Src/VimMac/VimMac.csproj /t:InstallAddin
+dotnet msbuild VimMac.csproj /t:InstallAddin

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,12 +1,7 @@
-echo "Downloading Mono"
-wget --quiet https://download.visualstudio.microsoft.com/download/pr/2516b6e5-6965-4f5b-af68-d1959a446e7a/443346a56436b5e2682b7c5b5b25e990/monoframework-mdk-6.12.0.125.macos10.xamarin.universal.pkg
-
-sudo installer -pkg monoframework-mdk-6.12.0.125.macos10.xamarin.universal.pkg -target /
-
 echo "Downloading VSMac"
-wget --quiet https://download.visualstudio.microsoft.com/download/pr/e5b7cb77-1248-4fb7-a3fe-532ca3335f78/777b586636b0cdba9db15d69bf8d8b1f/visualstudioformac-8.9.7.8.dmg
+wget --quiet https://download.visualstudio.microsoft.com/download/pr/40d0790a-f7b7-44d3-a6e5-9bc5677fb1d7/28697450215d02cbec72e943d988f51f/visualstudioformacpreviewinstaller-17.0.0.149.dmg
 
-sudo hdiutil attach visualstudioformac-8.9.7.8.dmg
+sudo hdiutil attach visualstudioformac-17.0.0.149.dmg
 
 echo "Removing pre-installed VSMac"
 sudo rm -rf "/Applications/Visual Studio.app"
@@ -19,10 +14,10 @@ rm -rf ~/Library/Preferences/Xamarin/
 rm -rf ~/Library/Developer/Xamarin
 rm -rf ~/Library/Application\ Support/VisualStudio
 
-echo "Installing VSMac 8.9"
-ditto -rsrc "/Volumes/Visual Studio/" /Applications/
+echo "Installing VSMac 17.0 Preview"
+ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
 
-msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore /t:Build
+dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore /t:Build
 
 # Generate Vim.Mac.VsVim_2.8.0.0.mpack extension artifact
 msbuild Src/VimMac/VimMac.csproj /t:InstallAddin

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -11,7 +11,7 @@ rm -rf ~/Library/Preferences/Xamarin/
 rm -rf ~/Library/Developer/Xamarin
 rm -rf ~/Library/Application\ Support/VisualStudio
 
-cho "Installing VSMac 17.0 Preview"
+echo "Installing VSMac 17.0 Preview"
 ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
 
 echo "Installing dotnet 6.0.1xx"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -3,9 +3,6 @@ wget --quiet https://download.visualstudio.microsoft.com/download/pr/a643750b-86
 
 sudo hdiutil attach visualstudioformac-preview-17.0.0.8001-pre.7-x64.dmg
 
-echo "Removing pre-installed VSMac"
-sudo rm -rf "/Applications/Visual Studio.app"
-rm -rf ~/Library/Caches/VisualStudio
 rm -rf ~/Library/Preferences/VisualStudio
 rm -rf ~/Library/Preferences/Visual\ Studio
 rm -rf ~/Library/Logs/VisualStudio
@@ -14,8 +11,8 @@ rm -rf ~/Library/Preferences/Xamarin/
 rm -rf ~/Library/Developer/Xamarin
 rm -rf ~/Library/Application\ Support/VisualStudio
 
-echo "Installing VSMac 17.0 Preview"
-ditto -rsrc "/Volumes/Visual Studio for Mac Preview Installer/" /Applications/
+cho "Installing VSMac 17.0 Preview"
+ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
 
 echo "Installing dotnet 6.0.1xx"
 wget https://dot.net/v1/dotnet-install.sh

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,7 +1,7 @@
 echo "Downloading VSMac"
-wget --quiet https://download.visualstudio.microsoft.com/download/pr/40d0790a-f7b7-44d3-a6e5-9bc5677fb1d7/28697450215d02cbec72e943d988f51f/visualstudioformacpreviewinstaller-17.0.0.149.dmg
+wget --quiet https://download.visualstudio.microsoft.com/download/pr/a643750b-8690-4e7b-a088-9dfc3b2865ba/f315ac486e00a8c3954df7127c0bf526/visualstudioformac-preview-17.0.0.8001-pre.7-x64.dmg
 
-sudo hdiutil attach visualstudioformacpreviewinstaller-17.0.0.149.dmg
+sudo hdiutil attach visualstudioformac-preview-17.0.0.8001-pre.7-x64.dmg
 
 echo "Removing pre-installed VSMac"
 sudo rm -rf "/Applications/Visual Studio.app"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -15,9 +15,9 @@ rm -rf ~/Library/Developer/Xamarin
 rm -rf ~/Library/Application\ Support/VisualStudio
 
 echo "Installing VSMac 17.0 Preview"
-ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
+ditto -rsrc "/Volumes/Visual Studio for Mac Preview Installer/" /Applications/
 
 dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore /t:Build
 
-# Generate Vim.Mac.VsVim_2.8.0.0.mpack extension artifact
+# Generate mpack extension artifact
 dotnet msbuild Src/VimMac/VimMac.csproj /t:InstallAddin

--- a/Src/VimCore/FSharpUtil.fs
+++ b/Src/VimCore/FSharpUtil.fs
@@ -584,7 +584,7 @@ module CharUtil =
     let IsTagNameChar x = System.Char.IsLetterOrDigit(x) || x = ':' || x = '.' || x = '_' || x = '-'
     let IsFileNameChar x = IsTagNameChar x
     let IsPrintable x =
-        let category = CharUnicodeInfo.GetUnicodeCategory(x)
+        let category = CharUnicodeInfo.GetUnicodeCategory(x: char)
         PrintableCategories.Contains category
     let ToLower x = System.Char.ToLower(x)
     let ToUpper x = System.Char.ToUpper(x)
@@ -970,7 +970,7 @@ module internal SystemUtil =
         else
             Some text
 
-    let EnsureRooted currentDirectory text = 
+    let EnsureRooted (currentDirectory: string) (text: string) = 
         if Path.IsPathRooted text || not (Path.IsPathRooted currentDirectory) then
             text
         else
@@ -980,7 +980,7 @@ module internal SystemUtil =
     /// isn't rooted it will be rooted inside of 'currentDirectory'
     ///
     /// This method can throw when provided paths with invalid path characters.
-    let ResolveVimPath currentDirectory text = 
+    let ResolveVimPath (currentDirectory: string) text = 
         match text with
         | "." -> currentDirectory
         | ".." -> Path.GetPathRoot currentDirectory

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -683,7 +683,7 @@ type VimInterpreter
             // cd is given no options
             _statusUtil.OnStatus x.CurrentDirectory
         | _ ->
-            let directoryPath = x.InterpretSymbolicPath symbolicPath
+            let (directoryPath: string) = x.InterpretSymbolicPath symbolicPath
             let directoryPath = 
                 if not (Path.IsPathRooted directoryPath) then
                     Path.GetFullPath(Path.Combine(_vimData.CurrentDirectory, directoryPath))
@@ -1440,7 +1440,7 @@ type VimInterpreter
     member x.RunVimHelp (subject: string) = 
         let subject = subject.Replace("*", "star")
 
-        let extractFolderVersion = fun pathName ->
+        let extractFolderVersion = fun (pathName: string) ->
             let folder = System.IO.Path.GetFileName(pathName)
             let m = System.Text.RegularExpressions.Regex.Match(folder, "^vim(\d+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase)
             match m with

--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Core</RootNamespace>
     <AssemblyName>Vim.Core</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OtherFlags>--standalone</OtherFlags>
     <NoWarn>2011</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
@@ -142,26 +142,16 @@
     <!-- Using element form vs. attributes to work around NuGet restore bug
          https://github.com/NuGet/Home/issues/6367 
          https://github.com/dotnet/project-system/issues/3493 -->
-    <PackageReference Include="FSharp.Core">
-      <Version>4.6.2</Version>
+    <PackageReference Include="FSharp.Core" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-
-    <!-- Excluding thes package to avoid the auto-include that is happening 
-         via F# targets and hittnig a restore issue in 15.7
-         https://github.com/NuGet/Home/issues/6936 -->
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.3.1</Version>
-      <ExcludeAssets>all</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference> 
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.UI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Core</RootNamespace>
     <AssemblyName>Vim.Core</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OtherFlags>--standalone</OtherFlags>
     <NoWarn>2011</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/Src/VimMac/Properties/AddinInfo.cs
+++ b/Src/VimMac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly: Addin(
     "VsVim",
     Namespace = "Vim.Mac",
-    Version = "2.8.0.14"
+    Version = "2.8.0.15"
 )]
 
 [assembly: AddinName("VsVim")]

--- a/Src/VimMac/RelativeLineNumbers/CocoaExtensions.cs
+++ b/Src/VimMac/RelativeLineNumbers/CocoaExtensions.cs
@@ -11,6 +11,7 @@ using CoreAnimation;
 using CoreGraphics;
 using CoreText;
 using Foundation;
+using ObjCRuntime;
 
 namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
 {

--- a/Src/VimMac/RelativeLineNumbers/CocoaLineNumberMarginDrawingVisual.cs
+++ b/Src/VimMac/RelativeLineNumbers/CocoaLineNumberMarginDrawingVisual.cs
@@ -6,6 +6,7 @@ using CoreAnimation;
 using CoreGraphics;
 using CoreText;
 using Foundation;
+using ObjCRuntime;
 using Vim.UI.Wpf.Implementation.RelativeLineNumbers;
 
 namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers

--- a/Src/VimMac/VimMac.csproj
+++ b/Src/VimMac/VimMac.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VimCore\VimCore.fsproj" />
-    <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0-preview.7955" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Src/VimMac/VimMac.csproj
+++ b/Src/VimMac/VimMac.csproj
@@ -6,8 +6,9 @@
     <AssemblyName>Vim.Mac</AssemblyName>
     <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_MAC</DefineConstants>
+    <!-- Suppress warning CA1416 -->
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
-      
   <ItemGroup>
     <AddinReference Include="MonoDevelop.TextEditor.Cocoa" />
   </ItemGroup>

--- a/Src/VimMac/VimMac.csproj
+++ b/Src/VimMac/VimMac.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Mac</RootNamespace>
     <AssemblyName>Vim.Mac</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_MAC</DefineConstants>
   </PropertyGroup>
       
@@ -12,13 +12,8 @@
     <AddinReference Include="MonoDevelop.TextEditor.Cocoa" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.ComponentModel.Composition" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\VimCore\VimCore.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
+    <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Test/VimCoreTest/CodeHygieneTest.cs
+++ b/Test/VimCoreTest/CodeHygieneTest.cs
@@ -64,7 +64,8 @@ namespace Vim.UnitTest
                 {
                     if (type.FullName.StartsWith("<Startup", StringComparison.Ordinal) ||
                         type.FullName.StartsWith("Microsoft.FSharp", StringComparison.Ordinal) ||
-                        type.FullName.StartsWith("Microsoft.BuildSettings", StringComparison.Ordinal))
+                        type.FullName.StartsWith("Microsoft.BuildSettings", StringComparison.Ordinal) ||
+                        type.FullName.StartsWith("FSharp.BuildProperties", StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:
 jobs:
 - job: macOS
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
   - script: VERSION_TAG=`git describe --tags` && echo "##vso[task.setvariable variable=VERSION_TAG]$VERSION_TAG"
     displayName: Set the tag name as an environment variable

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
 
 - job: VsVim_Build_Test
   pool: 
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
 
   steps:
 
@@ -89,7 +89,7 @@ jobs:
 #   - The Open VSIX gallery during CI
 - job: Produce_Vsix
   pool: 
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
 
   steps:
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ pr:
 - dev/jaredpar/*
 - master
 
-# Standard CI loop (build and test). This will run against VS2017 and VS2019
+# Standard CI loop (build and test). This will run against VSMac 17.0
 jobs:
 - job: macOS
   pool:
@@ -26,7 +26,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: Binaries/Debug/VimMac/net472/Vim.Mac.VsVim_$(EXTENSION_VERSION).mpack
+      pathToPublish: Binaries/Debug/VimMac/net6.0/Vim.Mac.VsVim_$(EXTENSION_VERSION).mpack
       artifactName: VSMacExtension
 
   - task: GitHubRelease@0
@@ -39,10 +39,11 @@ jobs:
       target: '$(Build.SourceVersion)'
       tagSource: 'auto'
       title: 'Visual Studio for Mac $(VERSION_TAG)'
-      assets: Binaries/Debug/VimMac/net472/Vim.Mac.VsVim_$(EXTENSION_VERSION).mpack
+      assets: Binaries/Debug/VimMac/net6.0/Vim.Mac.VsVim_$(EXTENSION_VERSION).mpack
       assetUploadMode: 'replace'
       isDraft: false
 
+# Standard CI loop (build and test). This will run against VS2017 and VS2019
 - job: VsVim_Build_Test
   pool: 
     vmImage: 'windows-2022'

--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,6 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vsmacsdk" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/VSMac/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,5 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
-    <add key="vsmacsdk" value="https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/VSMac/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Since some common types got moved out of the `System` namespace in `net6` (`nfloat` etc), there are now some exceptions that causes the extension to not function correctly in VSMac in some cases.

The only way to resolve these issues are to build the extension against the same set of assemblies as the preview version of VSMac. We've been building against an old version (8.4) for quite some time now. This also implies that this extension will need to use `net6` as the TargetFramework. 