### PR TITLE
Push MS.VS.Threading into VimCore

### DIFF
--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -7,6 +7,7 @@ open Microsoft.VisualStudio.Text.Operations
 open Microsoft.VisualStudio.Text.Outlining
 open Microsoft.VisualStudio.Text.Classification
 open Microsoft.VisualStudio.Text.Tagging
+open Microsoft.VisualStudio.Threading
 open Microsoft.VisualStudio.Utilities
 open System.Diagnostics
 open System.IO
@@ -6126,6 +6127,8 @@ module internal VimCoreExtensions =
 /// dispatched operation will go directly to the dispatch loop and crash the host
 /// application
 type IProtectedOperations = 
+
+    abstract member JoinableTaskContext: JoinableTaskContext
 
     /// Get an Action delegate which invokes the original action and handles any
     /// thrown Exceptions by passing them off the the available IExtensionErrorHandler

--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -146,15 +146,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.UI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
 </Project>

--- a/Src/VimEditorHost/UnitTests/VimTestBase.cs
+++ b/Src/VimEditorHost/UnitTests/VimTestBase.cs
@@ -28,6 +28,7 @@ using Vim.Extensions;
 using Vim.EditorHost.Implementation.Misc;
 using Vim.UI.Wpf;
 using Vim.UI.Wpf.Implementation.Misc;
+using Microsoft.VisualStudio.Threading;
 
 namespace Vim.UnitTest
 {
@@ -50,6 +51,11 @@ namespace Vim.UnitTest
         public StaContext StaContext { get; }
         public Dispatcher Dispatcher => StaContext.Dispatcher;
         public DispatcherSynchronizationContext DispatcherSynchronizationContext { get; }
+
+        public JoinableTaskContext JoinableTaskContext
+        {
+            get { return _vimEditorHost.JoinableTaskContext; }
+        }
 
         public CompositionContainer CompositionContainer
         {

--- a/Src/VimEditorHost/VimEditorHost.cs
+++ b/Src/VimEditorHost/VimEditorHost.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Text.Outlining;
 using Microsoft.VisualStudio.Utilities;
 using Vim.UI.Wpf;
 using Vim.UnitTest;
+using Microsoft.VisualStudio.Threading;
 
 namespace Vim.EditorHost
 {
@@ -49,6 +50,7 @@ namespace Vim.EditorHost
         internal IBulkOperations BulkOperations {get;}
         public IEditorFormatMapService EditorFormatMapService {get;}
         public IClassificationFormatMapService ClassificationFormatMapService {get;}
+        public JoinableTaskContext JoinableTaskContext { get; }
 
         public IVimData VimData => Vim.VimData;
         public IVimHost VimHost => Vim.VimHost;
@@ -83,6 +85,7 @@ namespace Vim.EditorHost
             ClipboardDevice = CompositionContainer.GetExportedValue<IClipboardDevice>();
             EditorFormatMapService = CompositionContainer.GetExportedValue<IEditorFormatMapService>();
             ClassificationFormatMapService = CompositionContainer.GetExportedValue<IClassificationFormatMapService>();
+            JoinableTaskContext = CompositionContainer.GetExportedValue<JoinableTaskContext>();
         }
 
         /// <summary>

--- a/Test/VimCoreTest/ProtectedOperationsTest.cs
+++ b/Test/VimCoreTest/ProtectedOperationsTest.cs
@@ -9,7 +9,7 @@ using Vim.UI.Wpf;
 
 namespace Vim.UnitTest
 {
-    public sealed class ProtectedOperationsTest
+    public sealed class ProtectedOperationsTest : VimTestBase
     {
         private readonly Mock<IExtensionErrorHandler> _errorHandler;
         private readonly ProtectedOperations _protectedOperationsRaw;
@@ -18,14 +18,14 @@ namespace Vim.UnitTest
         public ProtectedOperationsTest()
         {
             _errorHandler = new Mock<IExtensionErrorHandler>(MockBehavior.Strict);
-            _protectedOperationsRaw = new ProtectedOperations(_errorHandler.Object);
+            _protectedOperationsRaw = new ProtectedOperations(JoinableTaskContext, _errorHandler.Object);
             _protectedOperations = _protectedOperationsRaw;
         }
 
         /// <summary>
         /// Verify the returned action will execute the original one
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void GetProtectedAction_Standard()
         {
             var didRun = false;
@@ -38,7 +38,7 @@ namespace Vim.UnitTest
         /// Verify that when the original action throws that it is passed on to the
         /// listed IExtensionErrorHandlers
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void GetProtectedAction_Throws()
         {
             var exception = new Exception("hello world");
@@ -51,7 +51,7 @@ namespace Vim.UnitTest
         /// <summary>
         /// Verify the returned EventHandler will execute the original one
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void GetProtectedEventHandler_Standard()
         {
             var didRun = false;
@@ -64,7 +64,7 @@ namespace Vim.UnitTest
         /// Verify that when the original EventHandler throws that it is passed on to the
         /// listed IExtensionErrorHandlers
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void GetProtectedEventHandler_Throws()
         {
             var exception = new Exception("hello world");
@@ -77,7 +77,7 @@ namespace Vim.UnitTest
         /// <summary>
         /// Verify that the BeginInvoke will actually schedule the original action
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void BeginInvoke_Priority_Standard()
         {
             var didRun = false;
@@ -90,7 +90,7 @@ namespace Vim.UnitTest
         /// Verify that when an exception is thrown during processing that it makes it's way to the 
         /// IExtensionErrorHandler
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void BeginInvoke_Priority_Throws()
         {
             var exception = new Exception("hello world");
@@ -103,7 +103,7 @@ namespace Vim.UnitTest
         /// <summary>
         /// Verify that the BeginInvoke will actually schedule the original action
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void BeginInvoke_NoPriority_Standard()
         {
             var didRun = false;
@@ -116,7 +116,7 @@ namespace Vim.UnitTest
         /// Verify that when an exception is thrown during processing that it makes it's way to the 
         /// IExtensionErrorHandler
         /// </summary>
-        [Fact]
+        [WpfFact]
         public void BeginInvoke_NoPriority_Throws()
         {
             var exception = new Exception("hello world");

--- a/Test/VsVimSharedTest/CodeHygieneTest.cs
+++ b/Test/VsVimSharedTest/CodeHygieneTest.cs
@@ -57,7 +57,7 @@ namespace Vim.VisualStudio.UnitTest
         /// the Vim.Core assembly and not an actual reference. Too many ways that VS ships the DLL that
         /// it makes referencing it too difficult. Embedding is much more reliably.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "https://github.com/VsVim/VsVim/issues/2976")]
         public void FSharpCoreReferences()
         {
             var assemblyList = new[]


### PR DESCRIPTION
This moves the reference to Microsoft.VisualStudio.Threading down into VimCore. This assembly is now very central to how the editor works and having it not present in VimCore was causing issues reconciling some warnings / errors I was running into. 

I asked around this should not present a problem in Vs4Mac. This assembly is used there and `JoinableTaskContext` can be used in a MEF composition. But wanted @nosami to see this change going through to double check. 