### PR TITLE
Bump macOS on CI to 11 as 10.15 is deprecated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
 
   macos-build:
     name: MacOS Build and Publish
-    runs-on: macOS-10.15
+    runs-on: macOS-11
 
     steps:
       # Must use fetch-depth 0 because the workflow requires that tags be present


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/issues/5583