### PR TITLE
[VSMac] Fix split windows and tab movement commands

### DIFF
--- a/Src/VimMac/Properties/AddinInfo.cs
+++ b/Src/VimMac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly: Addin(
     "VsVim",
     Namespace = "Vim.Mac",
-    Version = "2.8.0.16"
+    Version = "2.8.0.17"
 )]
 
 [assembly: AddinName("VsVim")]

--- a/Src/VimMac/VimMac.csproj
+++ b/Src/VimMac/VimMac.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <AddinReference Include="MonoDevelop.TextEditor" />
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="Properties\" />
     <Folder Include="Resources\" />
     <Folder Include="FPFExtensions\" />


### PR DESCRIPTION
Fixes reflection based window management code for Cocoa based VSMac and removes
support for older versions.

This makes split windows and tab movements work again.

Fixes https://github.com/VsVim/VsVim/issues/2918