### PR TITLE
Handle alternative keyboard layouts a little better.

### DIFF
--- a/Src/VimMac/AlternateKeyUtil.cs
+++ b/Src/VimMac/AlternateKeyUtil.cs
@@ -236,10 +236,18 @@ namespace Vim.UI.Cocoa.Implementation.Misc
 
         private bool GetKeyInputFromKey(NSEvent theEvent, NSEventModifierMask modifierKeys, out KeyInput keyInput)
         {
-            if(!string.IsNullOrEmpty(theEvent.CharactersIgnoringModifiers))
+            if(!string.IsNullOrEmpty(theEvent.Characters))
             {
-                var keyModifiers = ConvertToKeyModifiers(modifierKeys);
-                keyInput = KeyInputUtil.ApplyKeyModifiersToChar(theEvent.CharactersIgnoringModifiers[0], keyModifiers);
+                VimKeyModifiers keyModifiers = VimKeyModifiers.None;
+                // With some keyboard layouts, Option + 4 produces the '$' symbol
+                // We don't want to convert this to Alt+$ as the modifier has already been applied here. 
+                // In this case, CharactersIgnoringModifiers = "4" and Characters = "$"
+                if (theEvent.CharactersIgnoringModifiers == theEvent.Characters)
+                {
+                    keyModifiers = ConvertToKeyModifiers(modifierKeys);
+                }
+
+                keyInput = KeyInputUtil.ApplyKeyModifiersToChar(theEvent.Characters[0], keyModifiers);
                 return true;
             }
             keyInput = null;

--- a/Src/VimMac/DeadCharHandler.cs
+++ b/Src/VimMac/DeadCharHandler.cs
@@ -1,0 +1,57 @@
+﻿using AppKit;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Vim.UI.Cocoa
+{
+    internal sealed class DeadCharHandler
+    {
+        private bool _lastEventWasDeadChar;
+        private bool _processingDeadChar;
+        private string _convertedDeadCharacters;
+        private readonly ITextView _textView;
+        private InvisibleTextView _invisibleTextView;
+
+        public DeadCharHandler(ITextView textView)
+        {
+            _textView = textView;
+        }
+
+        public string ConvertedDeadCharacters => _convertedDeadCharacters;
+
+        internal void SetConvertedDeadCharacters(string value)
+        {
+            _convertedDeadCharacters = value;
+        }
+
+        public bool LastEventWasDeadChar => _lastEventWasDeadChar;
+        public bool ProcessingDeadChar => _processingDeadChar;
+
+        public void InterpretEvent(NSEvent keyPress)
+        {
+            if (_convertedDeadCharacters != null)
+            {
+                // reset state
+                _convertedDeadCharacters = null;
+                _processingDeadChar = false;
+            }
+
+            _lastEventWasDeadChar = _processingDeadChar;
+
+            _processingDeadChar = KeyEventIsDeadChar(keyPress);
+
+            if (!_processingDeadChar && !_lastEventWasDeadChar)
+            {
+                return;
+            }
+
+            _invisibleTextView ??= new InvisibleTextView(this, _textView);
+            // Send the cloned key press to the invisible NSTextView
+            _invisibleTextView.InterpretEvent(keyPress);
+        }
+
+        private bool KeyEventIsDeadChar(NSEvent e)
+        {
+            return string.IsNullOrEmpty(e.Characters);
+        }
+    }
+}

--- a/Src/VimMac/InvisibleTextView.cs
+++ b/Src/VimMac/InvisibleTextView.cs
@@ -26,7 +26,7 @@ namespace Vim.UI.Cocoa
 
         private void TextBuffer_Changing(object sender, TextContentChangingEventArgs e)
         {
-            if(_processingDeadChar)
+            if(_lastEventWasDeadChar || _processingDeadChar)
             {
                 // We need the dead key press event to register so that we get the correct
                 // subsequent keypress vents, but we don't want to modify the textbuffer contents.

--- a/Src/VimMac/InvisibleTextView.cs
+++ b/Src/VimMac/InvisibleTextView.cs
@@ -24,16 +24,6 @@ namespace Vim.UI.Cocoa
             textView.Closed += TextView_Closed;
         }
 
-        private void TextBuffer_Changing(object sender, TextContentChangingEventArgs e)
-        {
-            if(_lastEventWasDeadChar || _processingDeadChar)
-            {
-                // We need the dead key press event to register so that we get the correct
-                // subsequent keypress vents, but we don't want to modify the textbuffer contents.
-                e.Cancel();
-            }
-        }
-
         public string ConvertedDeadCharacters => _convertedDeadCharacters;
 
         public void InterpretEvent(NSEvent keyPress)
@@ -54,6 +44,16 @@ namespace Vim.UI.Cocoa
                 // This is where we find out how the combination of keypresses
                 // has been interpreted.
                 _convertedDeadCharacters = text.ToString();
+            }
+        }
+
+        private void TextBuffer_Changing(object sender, TextContentChangingEventArgs e)
+        {
+            if(_lastEventWasDeadChar || _processingDeadChar)
+            {
+                // We need the dead key press event to register so that we get the correct
+                // subsequent keypress events, but we don't want to modify the textbuffer contents.
+                e.Cancel();
             }
         }
 

--- a/Src/VimMac/InvisibleTextView.cs
+++ b/Src/VimMac/InvisibleTextView.cs
@@ -1,0 +1,65 @@
+﻿using AppKit;
+using Foundation;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Vim.UI.Cocoa
+{
+    /// <summary>
+    /// An invisible NSTextView used so we can leverage macOS to handle
+    /// the conversion of keycodes and dead key presses into characters for
+    /// any keyboard layout.
+    /// </summary>
+    internal sealed class InvisibleTextView : NSTextView
+    {
+        private bool _lastEventWasDeadChar;
+        private bool _processingDeadChar;
+        private string _convertedDeadCharacters;
+        private ITextBuffer _textBuffer;
+
+        public InvisibleTextView(ITextView textView)
+        {
+            _textBuffer = textView.TextBuffer;
+            textView.TextBuffer.Changing += TextBuffer_Changing;
+            textView.Closed += TextView_Closed;
+        }
+
+        private void TextBuffer_Changing(object sender, TextContentChangingEventArgs e)
+        {
+            if(_processingDeadChar)
+            {
+                // We need the dead key press event to register so that we get the correct
+                // subsequent keypress vents, but we don't want to modify the textbuffer contents.
+                e.Cancel();
+            }
+        }
+
+        public string ConvertedDeadCharacters => _convertedDeadCharacters;
+
+        public void InterpretEvent(NSEvent keyPress)
+        {
+            _convertedDeadCharacters = null;
+            _lastEventWasDeadChar = _processingDeadChar;
+            _processingDeadChar = string.IsNullOrEmpty(keyPress.Characters);
+
+            var keypressCloned = NSEvent.KeyEvent(keyPress.Type, keyPress.LocationInWindow, keyPress.ModifierFlags, keyPress.Timestamp, keyPress.WindowNumber, keyPress.Context, keyPress.Characters, keyPress.CharactersIgnoringModifiers, keyPress.IsARepeat, keyPress.KeyCode);
+            // Send the cloned key press to this NSTextView
+            InterpretKeyEvents(new[] { keypressCloned });
+        }
+
+        public override void InsertText(NSObject text, NSRange replacementRange)
+        {
+            if (_lastEventWasDeadChar && !_processingDeadChar)
+            {
+                // This is where we find out how the combination of keypresses
+                // has been interpreted.
+                _convertedDeadCharacters = text.ToString();
+            }
+        }
+
+        private void TextView_Closed(object sender, System.EventArgs e)
+        {
+            _textBuffer.Changing -= TextBuffer_Changing;
+        }
+    }
+}

--- a/Src/VimMac/Properties/AddinInfo.cs
+++ b/Src/VimMac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly: Addin(
     "VsVim",
     Namespace = "Vim.Mac",
-    Version = "2.8.0.18"
+    Version = "2.8.0.19"
 )]
 
 [assembly: AddinName("VsVim")]

--- a/Src/VimMac/VimKeyProcessor.cs
+++ b/Src/VimMac/VimKeyProcessor.cs
@@ -6,7 +6,6 @@ using Vim.UI.Cocoa.Implementation.InlineRename;
 
 namespace Vim.UI.Cocoa
 {
-
     /// <summary>
     /// The morale of the history surrounding this type is translating key input is
     /// **hard**.  Anytime it's done manually and expected to be 100% correct it 
@@ -25,7 +24,7 @@ namespace Vim.UI.Cocoa
         private readonly ICompletionBroker _completionBroker;
         private readonly ISignatureHelpBroker _signatureHelpBroker;
         private readonly InlineRenameListenerFactory _inlineRenameListenerFactory;
-        private readonly InvisibleTextView _invisibleTextView;
+        private readonly DeadCharHandler _deadCharHandler;
 
         public VimKeyProcessor(
             IVimBuffer vimBuffer,
@@ -41,7 +40,7 @@ namespace Vim.UI.Cocoa
             _completionBroker = completionBroker;
             _signatureHelpBroker = signatureHelpBroker;
             _inlineRenameListenerFactory = inlineRenameListenerFactory;
-            _invisibleTextView = new InvisibleTextView(_textView);
+            _deadCharHandler = new DeadCharHandler(_textView);
         }
 
         public override bool IsInterestedInHandledEvents => true;
@@ -65,7 +64,7 @@ namespace Vim.UI.Cocoa
 
             bool handled = false;
 
-            _invisibleTextView.InterpretEvent(e.Event);
+            _deadCharHandler.InterpretEvent(e.Event);
             if (KeyEventIsDeadChar(e))
             {
                 // Although there is nothing technically left to do, we still
@@ -75,9 +74,9 @@ namespace Vim.UI.Cocoa
             }
             else
             {
-                if (_invisibleTextView.ConvertedDeadCharacters != null)
+                if (_deadCharHandler.ConvertedDeadCharacters != null)
                 {
-                    foreach (var c in _invisibleTextView.ConvertedDeadCharacters)
+                    foreach (var c in _deadCharHandler.ConvertedDeadCharacters)
                     {
                         var key = KeyInputUtil.CharToKeyInput(c);
                         handled &= TryProcess(null, key);

--- a/Src/VimMac/VimKeyProcessor.cs
+++ b/Src/VimMac/VimKeyProcessor.cs
@@ -79,7 +79,7 @@ namespace Vim.UI.Cocoa
                 {
                     foreach (var c in _invisibleTextView.ConvertedDeadCharacters)
                     {
-                        var key = KeyInputUtil.ApplyKeyModifiersToChar(c, VimKeyModifiers.None);
+                        var key = KeyInputUtil.CharToKeyInput(c);
                         handled &= TryProcess(null, key);
                     }
                 }


### PR DESCRIPTION
E.g. on a Swedish keyboard, you use Option+4 to enter `$` We want this to be treated as a $ press, not Alt+4 Fixes #3015