### PR TITLE
Use next bracket text object if cursor is not currently within a bracket text object

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -1954,6 +1954,18 @@ type internal CommandUtil
             else
                 CommandResult.Completed ModeSwitch.NoSwitch
 
+    /// Search for next open bracket after current caret position and return bracket text object if found
+    member x.GetNextBracketTextObject(motion: Motion) =
+        match motion with
+        | (Motion.AllBlock blockKind | Motion.InnerBlock blockKind) -> 
+            let startChar, _ = blockKind.Characters
+            let searchdata = SearchData(startChar.ToString(), SearchPath.Forward, false)
+            let searchResult = _vimTextBuffer.Vim.SearchService.FindNextPattern x.CaretPoint searchdata _wordUtil.SnapshotWordNavigator 1 
+            match searchResult with
+            | SearchResult.Found  (_, span, _, _)-> _motionUtil.GetTextObject motion span.Start
+            |_ -> None
+        |_ -> None
+
     /// Move the caret to the result of the text object selection
     member x.MoveCaretToTextObject count motion textObjectKind (visualSpan: VisualSpan) =
 
@@ -2038,7 +2050,6 @@ type internal CommandUtil
         let moveBlock blockKind motion =
             let argument = MotionArgument(MotionContext.Movement, operatorCount = None, motionCount = Some count)
             match _motionUtil.GetMotion motion argument with
-            | None -> onError ()
             | Some motionResult ->
                 let blockVisualSpan = VisualSpan.CreateForSpan motionResult.Span desiredVisualKind _localSettings.TabStop
                 if motionResult.Span.Length = 0 || visualSpan <> blockVisualSpan then
@@ -2057,6 +2068,14 @@ type internal CommandUtil
                     match contextPoint |> OptionUtil.map2 (fun point -> _motionUtil.GetTextObject motion point) with
                     | None -> onError()
                     | Some motionResult -> setSelection motionResult.Span
+            | None ->
+                match isInitialSelection with
+                | true ->
+                    //If no bracket text object found search for next open bracket and return found text object
+                    match x.GetNextBracketTextObject(motion) with
+                    | None -> onError()
+                    | Some motionResult -> setSelection motionResult.Span
+                | false-> onError()
 
         match motion with
         | Motion.AllBlock blockKind -> moveBlock blockKind motion
@@ -3260,11 +3279,16 @@ type internal CommandUtil
     /// if found to the provided function
     member x.RunWithMotion (motion: MotionData) func =
         match _motionUtil.GetMotion motion.Motion motion.MotionArgument with
-        | None ->
-            _commonOperations.Beep()
-            CommandResult.Error
         | Some data ->
             func data
+        | None ->
+                //If no block/bracket text object found search for next open bracket and return found text object
+                match x.GetNextBracketTextObject(motion.Motion) with
+                | None -> 
+                    _commonOperations.Beep()
+                    CommandResult.Error
+                | Some motionResult ->
+                    func motionResult
 
     /// Process the m[a-z] command
     member x.SetMarkToCaret c =

--- a/Test/VimCoreTest/VisualModeIntegrationTest.cs
+++ b/Test/VimCoreTest/VisualModeIntegrationTest.cs
@@ -4436,5 +4436,232 @@ namespace Vim.UnitTest
                 }
             }
         }
+
+        /// <summary>
+        /// Test bracket text object if caret is before (not inside or on) the text object
+        /// In this case the next bracket text object is searched and used if found
+        /// </summary>
+        public sealed class SelectNextBracketTextObjectTest : VisualModeIntegrationTest
+        {
+            List<string> openBrackets = new List<string> { "(", "[", "{", "<" };
+            List<string> closeBrackets = new List<string> { ")", "]", "}", ">" };
+            List<string> textObject = new List<string> { "b", "]", "B", ">" };
+
+            /// <summary>
+            /// Select next inner block single line
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNextInnerBlockSingleLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    string line = String.Format("cat {0}dog{1} fish", openBrackets[i], closeBrackets[i]);
+                    Create(line);
+                    _textView.MoveCaretTo(0);
+                    _vimBuffer.Process("vi" + textObject[i]);
+                    Assert.Equal("dog", _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(7, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select next all block single line
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNextAllBlockSingleLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    string line = String.Format("cat {0}dog{1} fish", openBrackets[i], closeBrackets[i]);
+                    Create(line);
+                    _textView.MoveCaretTo(0);
+                    _vimBuffer.Process("va" + textObject[i]);
+                    string expectedSelection = String.Format("{0}dog{1}", openBrackets[i], closeBrackets[i]);
+                    Assert.Equal(expectedSelection, _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(8, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select next inner block multi line
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNextInnerBlockMultiLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    Create("cat", openBrackets[i], "dog", closeBrackets[i], "fish");
+                    _textView.MoveCaretTo(0);
+                    _vimBuffer.Process("vi" + textObject[i]);
+                    Assert.Equal("dog", _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(11, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select next all block multi line
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNextAllBlockMultiLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    Create("cat", openBrackets[i], "dog", closeBrackets[i], "fish");
+                    _textView.MoveCaretTo(0);
+                    _vimBuffer.Process("va" + textObject[i]);
+                    string expectedSelection = String.Format("{0}\r\ndog\r\n{1}", openBrackets[i], closeBrackets[i]);
+                    Assert.Equal(expectedSelection, _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(13, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select current inner block single line (no search next block if within a block)
+            /// </summary>
+            [WpfFact]
+            public void SelectCurrentInnerBlockSingleLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    string line = String.Format("{0}cat {0}dog{1} fish{1}", openBrackets[i], closeBrackets[i]);
+                    Create(line);
+                    _textView.MoveCaretTo(1); //[c]at
+                    _vimBuffer.Process("vi" + textObject[i]);
+                    string expectedSelection = String.Format("cat {0}dog{1} fish", openBrackets[i], closeBrackets[i]);
+                    Assert.Equal(expectedSelection, _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(14, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select current all block single line (no search next block if within a block)
+            /// </summary>
+            [WpfFact]
+            public void SelectCurrentAllBlockSingleLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    string line = String.Format("{0}cat {0}dog{1} fish{1}", openBrackets[i], closeBrackets[i]);
+                    Create(line);
+                    _textView.MoveCaretTo(1); //[c]at
+                    _vimBuffer.Process("va" + textObject[i]);
+                    string expectedSelection = String.Format("{0}cat {0}dog{1} fish{1}", openBrackets[i], closeBrackets[i]);
+                    Assert.Equal(expectedSelection, _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(15, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select current inner block multi line (no search next block if within a block)
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectCurrentInnerBlockMultiLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    Create(openBrackets[i], "cat", openBrackets[i], "dog", closeBrackets[i], "fish", closeBrackets[i]);
+                    _textView.MoveCaretToLine(1); //[c]at
+                    _vimBuffer.Process("vi" + textObject[i]);
+                    string expectedSelection = String.Format("cat\r\n{0}\r\ndog\r\n{1}\r\nfish", openBrackets[i], closeBrackets[i]);
+                    Assert.Equal(expectedSelection, _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(23, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select current all block multi line (no search next block if within a block)
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectCurrentAllBlockMultiLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    Create(openBrackets[i], "cat", openBrackets[i], "dog", closeBrackets[i], "fish", closeBrackets[i]);
+                    _textView.MoveCaretToLine(1); //[c]at
+                    _vimBuffer.Process("va" + textObject[i]);
+                    string expectedSelection = String.Format("{0}\r\ncat\r\n{0}\r\ndog\r\n{1}\r\nfish\r\n{1}", openBrackets[i], closeBrackets[i]);
+                    Assert.Equal(expectedSelection, _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(25, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select no next inner block single line (no next block exists)
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNoNextInnerBlockSingleLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    string line = String.Format("cat {0}dog{1} fish", openBrackets[i], closeBrackets[i]);
+                    Create(line);
+                    _textView.MoveCaretTo(10);
+                    _vimBuffer.Process("vi" + textObject[i]);
+                    Assert.Equal("f", _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(10, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select no next all block single line (no next block exists)
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNoNextAllBlockSingleLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    string line = String.Format("cat {0}dog{1} fish", openBrackets[i], closeBrackets[i]);
+                    Create(line);
+                    _textView.MoveCaretTo(10);
+                    _vimBuffer.Process("va" + textObject[i]);
+                    Assert.Equal("f", _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(10, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select no next inner block multi line (no next block exists)
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNoNextInnerBlockMultiLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    Create("cat", openBrackets[i], "dog", closeBrackets[i], "fish");
+                    _textView.MoveCaretToLine(4);
+                    _vimBuffer.Process("vi" + textObject[i]);
+                    Assert.Equal("f", _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(16, _textView.GetCaretPoint().Position);
+                }
+            }
+
+            /// <summary>
+            /// Select no next all block multi line (no next block exists)
+            /// character
+            /// </summary>
+            [WpfFact]
+            public void SelectNoNextAllBlockMultiLine()
+            {
+                for (int i = 0; i < openBrackets.Count; i++)
+                {
+                    Create("cat", openBrackets[i], "dog", closeBrackets[i], "fish");
+                    _textView.MoveCaretToLine(4);
+                    _vimBuffer.Process("va" + textObject[i]);
+                    Assert.Equal("f", _textView.GetSelectionSpan().GetText());
+                    Assert.Equal(16, _textView.GetCaretPoint().Position);
+                }
+
+            }
+
+        }
     }
 }


### PR DESCRIPTION
Emulate the behavior of Vim (compared with gvim 9.0.57 on Windows) to use the next bracket text object when the cursor is not inside a bracket text object. The next bracket text object is searched using the opening bracket character.

Example (cursor is italic, selected text is bold):
_c_at (fish) dog -> vib -> cat (**fish**) dog
_c_at (fish) dog -> vab -> cat **(fish)** dog

Please double check PR, this is my first contact with VsVim source code and my first contact with F#.