### PR TITLE
Fix for d motion special case: if only an emty line will remain the motion becomes linewise

### DIFF
--- a/Src/VimCore/CommandUtil.fs
+++ b/Src/VimCore/CommandUtil.fs
@@ -979,15 +979,31 @@ type internal CommandUtil
         //
         // Now execute 'd/  ' (2 spaces after the /).  This will delete the entire cat and dog
         // line
+        //
+        //
+        // In the next case an emtpy line remain which also leads to linewise motion
+        //
+        // cat
+        // (  <--- Caret
+        // dog
+        // )
+        // fish
+        // 
+        // Now execute 'dab'. Result with empty line removed:
+        // cat
+        // fish
+        //
         let span, operationKind =
             let span = result.Span
             if result.LineRange.Count > 1 && result.OperationKind = OperationKind.CharacterWise then
                 let startLine, lastLine = SnapshotSpanUtil.GetStartAndLastLine span
-                let lastPoint =
-                    if result.IsExclusive then result.End
-                    else result.LastOrStart
+
+                let firstPointAfterSpan =
+                      if result.IsExclusive then span.End
+                      else span.End.Add(1)
+
                 let endsInWhiteSpace =
-                    lastPoint
+                    firstPointAfterSpan
                     |> SnapshotPointUtil.GetPoints SearchPath.Forward
                     |> Seq.takeWhile (fun point -> point.Position < lastLine.End.Position)
                     |> Seq.forall SnapshotPointUtil.IsWhiteSpace

--- a/Test/VimCoreTest/NormalModeIntegrationTest.cs
+++ b/Test/VimCoreTest/NormalModeIntegrationTest.cs
@@ -8852,6 +8852,91 @@ namespace Vim.UnitTest
                 _vimBuffer.Process("d/  ", enter: true);
                 Assert.Equal(1, _textBuffer.CurrentSnapshot.LineCount);
                 Assert.Equal(" fish", _textBuffer.GetLine(0).GetText());
+            } 
+            
+            /// <summary>
+            /// At the end of the ':help d{motion}` entry it lists a special case where the command
+            /// becomes linewise.  When it's a multiline delete and there is whitespace before / after
+            /// the span.  
+            /// In this test case the remaining empty line will also removed
+            /// </summary>
+            [WpfFact]
+            public void DeleteMotionSpecialCaseABracketBlock()
+            {
+                Create("cat", "(", "dog", ")", "fish");
+                _textView.MoveCaretToLine(1);
+                _vimBuffer.Process("dab", enter: true);
+                Assert.Equal(2, _textBuffer.CurrentSnapshot.LineCount);
+                Assert.Equal("cat", _textBuffer.GetLine(0).GetText());
+                Assert.Equal("fish", _textBuffer.GetLine(1).GetText());
+            }
+
+            /// <summary>
+            /// At the end of the ':help d{motion}` entry it lists a special case where the command
+            /// becomes linewise.  When it's a multiline delete and there is whitespace before / after
+            /// the span.  
+            /// In this test case the remaining empty line and whitespaces will be removed
+            /// </summary>
+            [WpfFact]
+            public void DeleteMotionSpecialCaseABracketBlockWithhitespace()
+            {
+                Create("cat", "(", "dog    ", ")", "fish");
+                _textView.MoveCaretToLine(1);
+                _vimBuffer.Process("dab", enter: true);
+                Assert.Equal(2, _textBuffer.CurrentSnapshot.LineCount);
+                Assert.Equal("cat", _textBuffer.GetLine(0).GetText());
+                Assert.Equal("fish", _textBuffer.GetLine(1).GetText());
+            }
+
+            /// <summary>
+            /// At the end of the ':help d{motion}` entry it lists a special case where the command
+            /// becomes linewise.  When it's a multiline delete and there is whitespace before / after
+            /// the span.  
+            /// This test case hase no whitespace before the span
+            /// </summary>
+            [WpfFact]
+            public void DeleteMotionSpecialCaseNoWhiteSpaceBeforeSpan()
+            {
+                Create(" Acat", " dog    ", " fish");
+                _textView.MoveCaretTo(2);
+                _vimBuffer.Process("d/  ", enter: true);
+                Assert.Equal(2, _textBuffer.CurrentSnapshot.LineCount);
+                Assert.Equal(" A    ", _textBuffer.GetLine(0).GetText());
+                Assert.Equal(" fish", _textBuffer.GetLine(1).GetText());
+            }
+
+            /// <summary>
+            /// At the end of the ':help d{motion}` entry it lists a special case where the command
+            /// becomes linewise.  When it's a multiline delete and there is whitespace before / after
+            /// the span.  
+            /// This test case hase no whitespace after the span
+            /// </summary>
+            [WpfFact]
+            public void DeleteMotionSpecialCaseNoWhiteSpaceAfterSpan()
+            {
+                Create(" cat", " dogZ    ", " fish");
+                _textView.MoveCaretTo(1);
+                _vimBuffer.Process("d/Z", enter: true);
+                Assert.Equal(2, _textBuffer.CurrentSnapshot.LineCount);
+                Assert.Equal(" Z    ", _textBuffer.GetLine(0).GetText());
+                Assert.Equal(" fish", _textBuffer.GetLine(1).GetText());
+            }
+
+            /// <summary>
+            /// At the end of the ':help d{motion}` entry it lists a special case where the command
+            /// becomes linewise.  When it's a multiline delete and there is whitespace before / after
+            /// the span.  
+            /// This test case hase no whitespace before and after the span
+            /// </summary>
+            [WpfFact]
+            public void DeleteMotionSpecialCaseNoWhiteSpaceBeforeAndAfterSpan()
+            {
+                Create(" Acat", " dogZ    ", " fish");
+                _textView.MoveCaretTo(2);
+                _vimBuffer.Process("d/Z    ", enter: true);
+                Assert.Equal(2, _textBuffer.CurrentSnapshot.LineCount);
+                Assert.Equal(" AZ    ", _textBuffer.GetLine(0).GetText());
+                Assert.Equal(" fish", _textBuffer.GetLine(1).GetText());
             }
 
             /// <summary>


### PR DESCRIPTION
Fix for d motion special case if only en emtpy line wil remain. In this case the motion will be linewise.

Example:

cat
(  <--- Caret
dog
)
fish

Execute 'dab'.

before fix:
cat
[wrong empty line]
fish

after fix (empty line removed due to linewise motion):
cat
fish