### PR TITLE
VSMac 17.6 / .Net 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,5 +100,5 @@ jobs:
           name: 'Visual Studio for Mac ${{ env.VERSION_TAG }}'
           draft: false
           generate_release_notes: true
-          files: 'Binaries/Debug/VimMac/net6.0-macos/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'
+          files: 'Binaries/Debug/VimMac/net7.0/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'
         if: ${{ success() && startsWith(github.ref, 'refs/tags') && contains(github.ref, 'vsm') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: VSMacExtension
-          path: 'Binaries/Debug/VimMac/net6.0-macos/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'
+          path: 'Binaries/Debug/VimMac/net7.0/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'
 
       - name: Create VS Mac extension release
         uses: softprops/action-gh-release@v1

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -4,14 +4,14 @@
 
  hdiutil attach `basename $url`
 
- echo "Installing VSMac 17.6"
- ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
- ls -la /Applications/
+echo "Installing VSMac 17.6"
+ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
+ls -la /Applications/
 
- echo "installing dotnet 6.0.3xx"
- wget https://dot.net/v1/dotnet-install.sh
- bash dotnet-install.sh --channel 6.0.3xx
- sudo ~/.dotnet/dotnet workload install macos
+echo "installing dotnet 7.0.2xx"
+wget https://dot.net/v1/dotnet-install.sh
+bash dotnet-install.sh --channel 7.0.2xx
+~/.dotnet/dotnet workload install macos
 
 echo "Building the extension"
 ~/.dotnet/dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,8 +1,8 @@
- echo "Downloading VSMac"
+echo "Downloading VSMac"
  url="https://download.visualstudio.microsoft.com/download/pr/93f43532-c75a-43bf-a335-9c62d3ad7c56/a0c1df1aa17141472362c80cef1a2581/visualstudioformac-preview-17.6.0.402-pre.1-x64.dmg"
- wget --quiet $url
+wget --quiet $url
 
- hdiutil attach `basename $url`
+hdiutil attach `basename $url`
 
 echo "Removing existing VSMac installation"
 sudo rm -rf "/Applications/Visual Studio.app"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -9,7 +9,7 @@ sudo rm -rf "/Applications/Visual Studio.app"
 
 echo "Installing VSMac 17.6"
 ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
-mv "/Applications/Visual Studio (Preview)" "/Applications/Visual Studio"
+mv "/Applications/Visual Studio (Preview).app" "/Applications/Visual Studio.app"
 ls -la /Applications/
 
 echo "installing dotnet 7.0.2xx"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -9,6 +9,7 @@ sudo rm -rf "/Applications/Visual Studio.app"
 
 echo "Installing VSMac 17.6"
 ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
+mv "/Applications/Visual Studio (Preview)" "/Applications/Visual Studio"
 ls -la /Applications/
 
 echo "installing dotnet 7.0.2xx"

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,17 +1,17 @@
-echo "Downloading VSMac"
-url="https://download.visualstudio.microsoft.com/download/pr/e81e04d3-768a-4310-9c9b-f32e8ba00eaa/889c20580d7989524e9b42726510452e/visualstudioformac-17.3.0.2102-x64.dmg"
-wget --quiet $url
+ echo "Downloading VSMac"
+ url="https://download.visualstudio.microsoft.com/download/pr/93f43532-c75a-43bf-a335-9c62d3ad7c56/a0c1df1aa17141472362c80cef1a2581/visualstudioformac-preview-17.6.0.402-pre.1-x64.dmg"
+ wget --quiet $url
 
-hdiutil attach `basename $url`
+ hdiutil attach `basename $url`
 
-echo "Installing VSMac 17.3"
-ditto -rsrc "/Volumes/Visual Studio/" /Applications/
-ls -la /Applications/
+ echo "Installing VSMac 17.6"
+ ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
+ ls -la /Applications/
 
-echo "installing dotnet 6.0.3xx"
-wget https://dot.net/v1/dotnet-install.sh
-bash dotnet-install.sh --channel 6.0.3xx
-sudo ~/.dotnet/dotnet workload install macos
+ echo "installing dotnet 6.0.3xx"
+ wget https://dot.net/v1/dotnet-install.sh
+ bash dotnet-install.sh --channel 6.0.3xx
+ sudo ~/.dotnet/dotnet workload install macos
 
 echo "Building the extension"
 ~/.dotnet/dotnet msbuild /p:Configuration=ReleaseMac /p:Platform="Any CPU" /t:Restore

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -5,7 +5,7 @@
  hdiutil attach `basename $url`
 
 echo "Removing existing VSMac installation"
-sudo rm -rf "/Applications/Visual Studio"
+sudo rm -rf "/Applications/Visual Studio.app"
 
 echo "Installing VSMac 17.6"
 ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -4,6 +4,9 @@
 
  hdiutil attach `basename $url`
 
+echo "Removing existing VSMac installation"
+sudo rm -rf "/Applications/Visual Studio"
+
 echo "Installing VSMac 17.6"
 ditto -rsrc "/Volumes/Visual Studio (Preview)/" /Applications/
 ls -la /Applications/

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,5 +1,5 @@
 echo "Downloading VSMac"
- url="https://download.visualstudio.microsoft.com/download/pr/93f43532-c75a-43bf-a335-9c62d3ad7c56/a0c1df1aa17141472362c80cef1a2581/visualstudioformac-preview-17.6.0.402-pre.1-x64.dmg"
+url="https://download.visualstudio.microsoft.com/download/pr/93f43532-c75a-43bf-a335-9c62d3ad7c56/a0c1df1aa17141472362c80cef1a2581/visualstudioformac-preview-17.6.0.402-pre.1-x64.dmg"
 wget --quiet $url
 
 hdiutil attach `basename $url`

--- a/Src/VimCore/AutoCommandRunner.fs
+++ b/Src/VimCore/AutoCommandRunner.fs
@@ -50,7 +50,7 @@ type internal AutoCommandRunner
         let bclPattern = builder.ToString()
         VimRegexFactory.CreateBcl bclPattern RegexOptions.None
 
-    static let FileNameEndsWithPattern fileName pattern = 
+    static let FileNameEndsWithPattern (fileName: string) pattern = 
         try
             let regex = CreateFilePatternRegex pattern
             match regex with 

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -715,7 +715,7 @@ type ISearchService =
 
     /// Find the next 'count' occurrence of the specified pattern.  Note: The first occurrence won't
     /// match anything at the provided start point.  That will be adjusted appropriately
-    abstract FindNextPattern: searchPoint: SnapshotPoint -> searchPoint: SearchData -> navigator: SnapshotWordNavigator -> count: int -> SearchResult
+    abstract FindNextPattern: searchPoint: SnapshotPoint -> searchData: SearchData -> navigator: SnapshotWordNavigator -> count: int -> SearchResult
 
 /// Column information about the caret in relation to this Motion Result
 [<RequireQualifiedAccess>]

--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -3,11 +3,12 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Core</RootNamespace>
     <AssemblyName>Vim.Core</AssemblyName>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net7.0</TargetFrameworks>
     <OtherFlags>--standalone</OtherFlags>
     <NoWarn>2011</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DebugType>portable</DebugType>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/Src/VimCore/VimRegex.fs
+++ b/Src/VimCore/VimRegex.fs
@@ -260,7 +260,7 @@ type VimRegex
     member x.Regex = _regex
     member x.IncludesNewLine = _includesNewLine
     member x.MatchesVisualSelection = _matchesVisualSelection
-    member x.IsMatch pattern = _regex.IsMatch(pattern)
+    member x.IsMatch (pattern: string) = _regex.IsMatch(pattern)
     member x.Replace (input: string) (replacement: string) (replaceData: VimRegexReplaceData) (registerMap: IRegisterMap) = 
         let collection = _regex.Matches(input)
         if collection.Count > 0 then

--- a/Src/VimMac/Properties/AddinInfo.cs
+++ b/Src/VimMac/Properties/AddinInfo.cs
@@ -5,7 +5,7 @@ using Mono.Addins.Description;
 [assembly: Addin(
     "VsVim",
     Namespace = "Vim.Mac",
-    Version = "2.8.0.19"
+    Version = "2.8.0.20"
 )]
 
 [assembly: AddinName("VsVim")]

--- a/Src/VimMac/RelativeLineNumbers/CocoaLineNumberMarginDrawingVisual.cs
+++ b/Src/VimMac/RelativeLineNumbers/CocoaLineNumberMarginDrawingVisual.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Globalization;
-
+using System.Runtime.InteropServices;
 using AppKit;
 using CoreAnimation;
 using CoreGraphics;
@@ -15,7 +15,7 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
     {
         private NSStringAttributes stringAttributes;
         private CGRect lineBounds;
-        private nfloat lineAscent;
+        private NFloat lineAscent;
         private CTLine ctLine;
 
         public int LineNumber { get; private set; }
@@ -37,7 +37,7 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
         internal void Update(
             NSStringAttributes stringAttributes,
             Line line,
-            nfloat lineWidth)
+            NFloat lineWidth)
         {
             // NOTE: keep this in sync with CocoaRenderedLineVisual regarding any font
             // metric handling, transforms, etc. Ensure that line numbers are always
@@ -63,7 +63,7 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
             AffineTransform = new CGAffineTransform(
                 1, 0,
                 0, 1,
-                0, (nfloat)line.TextTop);
+                0, (NFloat)line.TextTop);
 
             var transformRect = AffineTransform.TransformRect(new CGRect(
                 line.IsCaretLine ? 0 : lineWidth - lineBounds.Width, // right justify

--- a/Src/VimMac/RelativeLineNumbers/RelativeLineNumbersMargin.cs
+++ b/Src/VimMac/RelativeLineNumbers/RelativeLineNumbersMargin.cs
@@ -29,6 +29,7 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
         private ICocoaClassificationFormatMap _classificationFormatMap;
         private IClassificationTypeRegistryService _classificationTypeRegistry;
         internal NSStringAttributes _formatting;
+        private NSStringAttributes _currentLineFormatting;
 
         private int _visibleDigits = 5;
 
@@ -135,7 +136,12 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
 
             var font = _classificationFormatMap.GetTextProperties(lineNumberClassificaiton);
 
+            IClassificationType currentLineNumberClassification = _classificationTypeRegistry.GetClassificationType("Selected Line Number");
+
+            var currentLineNumberFont = _classificationFormatMap.GetTextProperties(currentLineNumberClassification);
+
             _formatting = font;
+            _currentLineFormatting = currentLineNumberFont;
 
             this.DetermineMarginWidth();
             Layer.BackgroundColor = (font.BackgroundColor ?? NSColor.Clear).CGColor;
@@ -208,6 +214,7 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
         private void UpdateLineNumbers()
         {
             _updateNeeded = false;
+            int currentLineNumber = _textView.Caret.Position.BufferPosition.GetContainingLine().LineNumber + 1;
 
             if (!Enabled)
             {
@@ -302,8 +309,16 @@ namespace Vim.UI.Cocoa.Implementation.RelativeLineNumbers
             void UpdateVisual(CocoaLineNumberMarginDrawingVisual visual, Line line)
             {
                 visual.InUse = true;
+
+                var formatting = _formatting;
+
+                if (line.LineNumber == currentLineNumber)
+                {
+                    formatting = _currentLineFormatting;
+                }
+
                 visual.Update(
-                    _formatting,
+                    formatting,
                     line,
                     intrinsicContentSize.Width);
             }

--- a/Src/VimMac/VimMac.csproj
+++ b/Src/VimMac/VimMac.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\VimCore\VimCore.fsproj" />
     <PackageReference Include="Microsoft.VisualStudioMac.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.5.0-2.final" />
   </ItemGroup>
   <ItemGroup>
     <AddinReference Include="MonoDevelop.TextEditor" />

--- a/Src/VimMac/VimMac.csproj
+++ b/Src/VimMac/VimMac.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Mac</RootNamespace>
     <AssemblyName>Vim.Mac</AssemblyName>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_MAC</DefineConstants>
     <!-- Suppress warning CA1416 -->
     <EnableNETAnalyzers>false</EnableNETAnalyzers>


### PR DESCRIPTION
VSMac 17.6 broke binary compatibility with previous versions and all addins targeting 17.6 and later need to be built against a minimum of vsmac 17.6.

This also requires .net 6.0 -> .net 7.0

I inadvertently included a commit from https://github.com/VsVim/VsVim/pull/3018 but happy to leave this in here if you are and I'll remove the other PR