### PR TITLE
Remove VSSDK targets

### DIFF
--- a/References/Vs2019/Vs2019.Build.targets
+++ b/References/Vs2019/Vs2019.Build.targets
@@ -31,6 +31,4 @@
       <Link>app.config</Link>
     </None>
   </ItemGroup>
-
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VsVimProjectType)' == 'Vsix' AND '$(VSToolsPath)' != ''" />
 </Project>

--- a/References/Vs2022/Vs2022.Build.targets
+++ b/References/Vs2022/Vs2022.Build.targets
@@ -28,6 +28,4 @@
       <Link>app.config</Link>
     </None>
   </ItemGroup>
-
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VsVimProjectType)' == 'Vsix' AND '$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
It seems these targets are not required and are currently causing build issues.
(See build log for https://github.com/VsVim/VsVim/pull/3077)