### PR TITLE
Fix warning FS3548:

### DIFF
--- a/Src/VimApp/VimApp.csproj
+++ b/Src/VimApp/VimApp.csproj
@@ -8,7 +8,8 @@
     <DefineConstants>$(DefineConstants);VS_SPECIFIC_VIM_APP</DefineConstants>
     <VsVimVisualStudioTargetVersion>17.0</VsVimVisualStudioTargetVersion>
     <VsVimProjectType>EditorHost</VsVimProjectType>
-
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
     <!-- 
 	    Disabling the VS threading analyzers here. This is a run of the mill WPF project and 
 		doesn't benefit from these analyzers.

--- a/Src/VimCore/CoreInterfaces.fs
+++ b/Src/VimCore/CoreInterfaces.fs
@@ -830,7 +830,7 @@ type MotionResult = {
         match x.MotionKind with
         | MotionKind.CharacterWiseExclusive -> OperationKind.CharacterWise
         | MotionKind.CharacterWiseInclusive -> OperationKind.CharacterWise
-        | MotionKind.LineWise _ -> OperationKind.LineWise
+        | MotionKind.LineWise -> OperationKind.LineWise
 
     /// Is this a word motion 
     member x.IsAnyWordMotion = Util.IsFlagSet x.MotionResultFlags MotionResultFlags.AnyWord
@@ -840,7 +840,7 @@ type MotionResult = {
         match x.MotionKind with
         | MotionKind.CharacterWiseExclusive -> true
         | MotionKind.CharacterWiseInclusive -> false
-        | MotionKind.LineWise _ -> false
+        | MotionKind.LineWise -> false
 
     /// Is this an inclusive motion
     member x.IsInclusive = not x.IsExclusive
@@ -1294,21 +1294,21 @@ type VisualKind =
     /// The TextSelectionMode this VisualKind would require
     member x.TextSelectionMode = 
         match x with
-        | Character _ -> TextSelectionMode.Stream
-        | Line _ -> TextSelectionMode.Stream
-        | Block _ -> TextSelectionMode.Box
+        | Character -> TextSelectionMode.Stream
+        | Line -> TextSelectionMode.Stream
+        | Block -> TextSelectionMode.Box
 
     member x.VisualModeKind = 
         match x with
-        | Character _ -> ModeKind.VisualCharacter
-        | Line _ -> ModeKind.VisualLine
-        | Block _ -> ModeKind.VisualBlock
+        | Character -> ModeKind.VisualCharacter
+        | Line -> ModeKind.VisualLine
+        | Block -> ModeKind.VisualBlock
 
     member x.SelectModeKind = 
         match x with
-        | Character _ -> ModeKind.SelectCharacter
-        | Line _ -> ModeKind.SelectLine
-        | Block _ -> ModeKind.SelectBlock
+        | Character -> ModeKind.SelectCharacter
+        | Line -> ModeKind.SelectLine
+        | Block -> ModeKind.SelectBlock
 
     static member All = [ Character; Line; Block ] |> Seq.ofList
 
@@ -2727,7 +2727,7 @@ with
         | ModeArgument.InsertWithTransaction transaction -> Some transaction
         | ModeArgument.Substitute _ -> Option.None
         | ModeArgument.PartialCommand _ -> Option.None
-        | ModeArgument.CancelOperation _ -> Option.None
+        | ModeArgument.CancelOperation -> Option.None
 
 
     /// Complete any embedded linked undo transaction
@@ -3265,7 +3265,7 @@ type NormalCommand =
         // Non-motion commands
         | NormalCommand.AddCaretAtMousePoint -> None
         | NormalCommand.AddCaretOnAdjacentLine _ -> None
-        | NormalCommand.AddToWord _ -> None
+        | NormalCommand.AddToWord -> None
         | NormalCommand.CancelOperation -> None
         | NormalCommand.ChangeCaseCaretLine _ -> None
         | NormalCommand.ChangeCaseCaretPoint _ -> None
@@ -3296,7 +3296,7 @@ type NormalCommand =
         | NormalCommand.GoToLocalDeclaration -> None
         | NormalCommand.GoToNextTab _ -> None
         | NormalCommand.GoToWindow _ -> None
-        | NormalCommand.GoToRecentView _ -> None
+        | NormalCommand.GoToRecentView -> None
         | NormalCommand.InsertAfterCaret -> None
         | NormalCommand.InsertBeforeCaret -> None
         | NormalCommand.InsertAtEndOfLine -> None

--- a/Src/VimCore/IncrementalSearch.fs
+++ b/Src/VimCore/IncrementalSearch.fs
@@ -48,7 +48,7 @@ type internal IncrementalSearchSession
 
     member x.Key = _key
     member x.IsWrap = _isWrap
-    member x.IsNotStarted = match _sessionState with | SessionState.NotStarted _ -> true | _ -> false
+    member x.IsNotStarted = match _sessionState with | SessionState.NotStarted -> true | _ -> false
     member x.IsStarted = match _sessionState with | SessionState.Started _ -> true | _ -> false
     member x.IsCompleted = match _sessionState with | SessionState.Completed -> true | _ -> false
     member x.IsActive = x.IsStarted && not x.IsCompleted

--- a/Src/VimCore/Interpreter_Interpreter.fs
+++ b/Src/VimCore/Interpreter_Interpreter.fs
@@ -2424,7 +2424,7 @@ type VimInterpreter
         | LineCommand.Execute expression -> x.RunExecute expression
         | LineCommand.Function func -> x.RunFunction func
         | LineCommand.FunctionStart _ -> cantRun ()
-        | LineCommand.FunctionEnd _ -> cantRun ()
+        | LineCommand.FunctionEnd -> cantRun ()
         | LineCommand.Files -> x.RunFiles()
         | LineCommand.Fold lineRange -> x.RunFold lineRange
         | LineCommand.Global (lineRange, pattern, matchPattern, lineCommand) -> x.RunGlobal lineRange pattern matchPattern lineCommand

--- a/Src/VimCore/Interpreter_Parser.fs
+++ b/Src/VimCore/Interpreter_Parser.fs
@@ -924,7 +924,7 @@ and [<Sealed>] internal Parser
             | LineCommand.Files -> noRangeCommand
             | LineCommand.Fold lineRange -> LineCommand.Fold lineRange
             | LineCommand.Function _ -> noRangeCommand
-            | LineCommand.FunctionEnd _ -> noRangeCommand
+            | LineCommand.FunctionEnd -> noRangeCommand
             | LineCommand.FunctionStart _ -> noRangeCommand
             | LineCommand.Global (_, pattern, matchPattern, lineCommand) -> LineCommand.Global (lineRange, pattern, matchPattern, lineCommand)
             | LineCommand.GoToFirstTab -> noRangeCommand

--- a/Src/VimCore/KeyMap.fs
+++ b/Src/VimCore/KeyMap.fs
@@ -382,7 +382,7 @@ type internal LocalAbbreviationMap
                     | KeyMappingResult.NeedsMoreInput _ -> abbreviation.Replacement
                     | KeyMappingResult.Mapped keyInputSet -> keyInputSet
                     | KeyMappingResult.PartiallyMapped (l, r) -> l.AddRange r
-                    | KeyMappingResult.Recursive _ -> abbreviation.Replacement
+                    | KeyMappingResult.Recursive -> abbreviation.Replacement
                     | KeyMappingResult.Unmapped _ -> abbreviation.Replacement
                 (replacement, Some result)
             else 

--- a/Src/VimCore/Modes_Insert_InsertMode.fs
+++ b/Src/VimCore/Modes_Insert_InsertMode.fs
@@ -463,7 +463,7 @@ type internal InsertMode
         | ActiveEditItem.None -> None
         | ActiveEditItem.OverwriteReplace -> None
         | ActiveEditItem.WordCompletion _ -> None
-        | ActiveEditItem.Special _ -> None
+        | ActiveEditItem.Special -> None
 
     member x.IsInPaste = x.PasteCharacter.IsSome
 

--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -599,7 +599,7 @@ type internal BlockUtil() =
                 |> isInStringLiteral referencePoint
                 with
                 | true, Some adjustedReferencePoint -> adjustedReferencePoint, false
-                | true, None _ -> referencePoint, true
+                | true, None -> referencePoint, true
                 | _ -> referencePoint, false
 
         // A literal point can answer whether a snapshot point is part of a
@@ -1111,7 +1111,7 @@ type internal MotionUtil
     /// Apply the 'startofline' option to the given MotionResult.  This function must be 
     /// called with the MotionData mapped back to the edit snapshot
     member x.ApplyStartOfLineOption (motionData: MotionResult) =
-        Contract.Assert(match motionData.MotionKind with MotionKind.LineWise _ -> true | _ -> false)
+        Contract.Assert(match motionData.MotionKind with MotionKind.LineWise -> true | _ -> false)
         Contract.Assert(motionData.Span.Snapshot = x.CurrentSnapshot)
         if not _globalSettings.StartOfLine then 
             motionData 
@@ -3284,7 +3284,7 @@ type internal MotionUtil
         match motionResult.MotionKind with
         | MotionKind.CharacterWiseExclusive -> adjust()
         | MotionKind.CharacterWiseInclusive -> motionResult
-        | MotionKind.LineWise _ -> motionResult
+        | MotionKind.LineWise -> motionResult
 
     /// Run the specified motion and return it's result
     member x.GetMotion motion (motionArgument: MotionArgument): MotionResult option = 

--- a/Src/VsVim2019/VsVim2019.csproj
+++ b/Src/VsVim2019/VsVim2019.csproj
@@ -19,6 +19,9 @@
 
     <!-- This is needed to prevent forced migrations when opening the project in Vs2017 -->
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/VsVim2022/VsVim2022.csproj
+++ b/Src/VsVim2022/VsVim2022.csproj
@@ -18,6 +18,9 @@
 
     <!-- This is needed to prevent forced migrations when opening the project in Vs2017 -->
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Test/VimCoreTest2019/VimCoreTest2019.csproj
+++ b/Test/VimCoreTest2019/VimCoreTest2019.csproj
@@ -10,6 +10,8 @@
     <DefineConstants>$(DefineConstants);VS_UNIT_TEST_HOST</DefineConstants>
     <!-- Enabling tracked by https://github.com/VsVim/VsVim/issues/2904 -->
     <RunAnalyzers>false</RunAnalyzers>
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/Test/VimCoreTest2022/VimCoreTest2022.csproj
+++ b/Test/VimCoreTest2022/VimCoreTest2022.csproj
@@ -9,6 +9,8 @@
     <DefineConstants>$(DefineConstants);VS_UNIT_TEST_HOST</DefineConstants>
     <!-- Enabling tracked by https://github.com/VsVim/VsVim/issues/2904 -->
     <RunAnalyzers>false</RunAnalyzers>
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/Test/VsVimTest2019/VsVimTest2019.csproj
+++ b/Test/VsVimTest2019/VsVimTest2019.csproj
@@ -10,6 +10,8 @@
     <DefineConstants>$(DefineConstants);VS_UNIT_TEST_HOST</DefineConstants>
     <!-- Enabling tracked by https://github.com/VsVim/VsVim/issues/2904 -->
     <RunAnalyzers>false</RunAnalyzers>
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/Test/VsVimTest2022/VsVimTest2022.csproj
+++ b/Test/VsVimTest2022/VsVimTest2022.csproj
@@ -9,6 +9,8 @@
     <DefineConstants>$(DefineConstants);VS_UNIT_TEST_HOST</DefineConstants>
     <!-- Enabling tracked by https://github.com/VsVim/VsVim/issues/2904 -->
     <RunAnalyzers>false</RunAnalyzers>
+    <!-- Temporary fix for https://github.com/dotnet/sdk/issues/34438 -->
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
Pattern discard is not allowed for union case that takes no data.

I suppose this is a new warning generated by the F# compiler.