### PR TITLE
VimCore: Explicitly set F# LangVersion to 8, fixing build where LangVersion 9 is stable

### DIFF
--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -5,6 +5,7 @@
     <AssemblyName>Vim.Core</AssemblyName>
     <TargetFrameworks>net472;net7.0</TargetFrameworks>
     <OtherFlags>--standalone</OtherFlags>
+    <LangVersion>8</LangVersion>
     <NoWarn>2011</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
VimCore currently can't be built with LangVersion 9, which is the default on the version of VS that I'm using.
This PR explicitly sets the VimCore project to build with LangVersion 8 as a workaround.

Attempting to build with LangVersion 9 results in the following errors:
```
Src\VimCore\CoreTypes.fs(77,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(147,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(467,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(874,18): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(985,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1155,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1229,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1292,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1403,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreTypes.fs(77,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(147,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(467,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(874,18): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(985,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1155,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1229,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1292,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\EditorUtil.fs(1403,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(86,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(105,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(113,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(121,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\Interpreter_Expression.fs(268,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\TaggingInterfaces.fs(75,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(748,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(1545,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(1740,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(4109,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(4814,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(5035,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(86,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(105,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(113,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\VimSettingsInterface.fs(121,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\Interpreter_Expression.fs(268,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\TaggingInterfaces.fs(75,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(748,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(1545,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(1740,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(4109,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(4814,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\CoreInterfaces.fs(5035,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\Modes_Insert_InsertMode.fs(147,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\TaggerUtil.fs(149,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\Modes_Insert_InsertMode.fs(147,3): error FS0842: This attribute is not valid for use on this language element
Src\VimCore\TaggerUtil.fs(149,3): error FS0842: This attribute is not valid for use on this language element
```