### PR TITLE
Add IntelliCodeExtensionAdapter class implementation to avoid vim to show on difference controls for edits.

### DIFF
--- a/Src/VsVimShared/Implementation/IntelliCode/IntelliCodeExtensionAdapter.cs
+++ b/Src/VsVimShared/Implementation/IntelliCode/IntelliCodeExtensionAdapter.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.Text.Editor;
+using System.ComponentModel.Composition;
+
+namespace Vim.VisualStudio.Implementation.IntelliCode;
+
+[Export(typeof(IExtensionAdapter))]
+internal sealed class IntelliCodeExtensionAdapter : VimExtensionAdapter
+{
+    private const string DifferenceViewerWithAdaptersRole = nameof(DifferenceViewerWithAdaptersRole);
+
+    [ImportingConstructor]
+    internal IntelliCodeExtensionAdapter()
+    {
+    }
+
+    // Suppress VsVim in the Embedded Difference Control elements.
+    protected override bool ShouldCreateVimBuffer(ITextView textView) =>
+        !IsEmbeddedDifferenceControlWindow(textView);
+
+    private static bool IsEmbeddedDifferenceControlWindow(ITextView textView)
+    {
+        if (textView.Roles.Contains(DifferenceViewerWithAdaptersRole))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Src/VsVimShared/VsVimShared.projitems
+++ b/Src/VsVimShared/VsVimShared.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\InlineRename\InlineRenameListenerFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\InlineRename\InlineRenameUtil.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\IntelliCode\IntelliCodeCommandTarget.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\Intellicode\IntelliCodeExtensionAdapter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Misc\CSharpAdapter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Misc\ExtensionAdapterBroker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\Misc\FallbackKeyProcessor.cs" />


### PR DESCRIPTION
In VS Copilot Chat features that insert code generated by the LLM we have an embedded view similar to a `Peek View` that allows us to display the differences that will be inserted, and allows the user to either refine on those using the embedded chat input or directly modifying the diffs, or accept/reject them when they are part of copilot edits experience.

Either way these difference views are only meant to display the differences but should not display a Vim buffer.

This change allows us to exclude these specific views from construct a Vim buffer.

Note: I added this under the IntelliCode folder because there was already a folder and namespace for IntelliCode, and we are the same team behind copilot for VS.

Before:
![image](https://github.com/user-attachments/assets/643510a2-8462-479f-bad2-3b559064db20)
(Note the vim buffer at the bottom of the element covering the last line of the difference element)

After:
![image](https://github.com/user-attachments/assets/d0ea950e-771b-469b-afa3-d50dce70fcac)
(All lines are now visible)