### PR TITLE
Add tag matching to % motion

### DIFF
--- a/Src/VimCore/MotionUtil.fs
+++ b/Src/VimCore/MotionUtil.fs
@@ -347,6 +347,12 @@ type MatchingTokenKind =
     // Curly braces
     | Braces
 
+    // Angled brackets
+    | Chevrons
+
+    // XML tag
+    | Tag
+
 /// Determine whether a given point is in a string literal by parsing forward
 /// from the beginning of the containing line
 type internal StringLiteralTestPoint
@@ -837,6 +843,47 @@ type MatchingTokenUtil() =
                 if directive.Span.Start = column then Some (column, MatchingTokenKind.Directive)
                 else None
 
+        // Finds a potential tag.
+        // Returns MatchingTokenKind.Chevrons when either:
+        // 1) Cursor is not inside a tag (searching for '<' and '>' forward)
+        // 2) Cursor is on top of either '<' or '>'
+        //
+        // It only returns Some when there is no whitespace on the "inside".  This is to prevent
+        // conditions like "foo < 10 && foo > 0" being matched, but is heavily dependant on codestyle,
+        // resulting in both false positives and negatives.
+        //
+        // In the future tag matching should be filetype dependant.
+        let findTag () =
+            // Finds char like string.LastIndexOf but prohibits certain char in between
+            let rec lastIndexOfProhibitChar (c: char) (index: int) (str: string) (prohibit: char) =
+                if index < 0 then
+                    None
+                else
+                    let current = str.[index]
+                    if current = prohibit then None
+                    elif current = c then Some index
+                    else lastIndexOfProhibitChar c (index - 1) str prohibit
+
+            if lineText.[column] = '<' then
+                if
+                    StringUtil.CharAtOption (column + 1) lineText
+                    |> Option.exists CharUtil.IsWhiteSpace
+                then None
+                else Some (column, MatchingTokenKind.Chevrons)
+            elif lineText.[column] = '>' then
+                if
+                    StringUtil.CharAtOption (column - 1) lineText
+                    |> Option.exists CharUtil.IsWhiteSpace
+                then None
+                else Some (column, MatchingTokenKind.Chevrons)
+            else
+                match lastIndexOfProhibitChar '<' column lineText '>' with
+                | None ->
+                    match StringUtil.IndexOfCharAt '<' column lineText with
+                    | None -> None
+                    | Some index -> Some (index, MatchingTokenKind.Chevrons)
+                | Some index -> Some (index, MatchingTokenKind.Tag)
+
         // Parse out all the possibilities and find the one that is closest to the 
         // column position
         let found = 
@@ -859,7 +906,7 @@ type MatchingTokenUtil() =
             // Lastly if there are no tokens that match on the current line but the line is a directive
             // block then it the match is the directive
             match directive with
-            | None -> None
+            | None -> findTag ()
             | Some directive -> Some (directive.Span.Start, MatchingTokenKind.Directive)
 
     member x.FindMatchingTokenKind lineText column =
@@ -953,6 +1000,21 @@ type MatchingTokenUtil() =
 
             found
 
+        // Find the matching tag starting from the buffer position 'target'
+        let findMatchingTag (target: int) =
+            let contextPoint = new SnapshotPoint(snapshot, target)
+            // Note that this approach results in "false positives" for <SelfClosingTags/>,
+            // cursor jumps to parent opening tag.
+            match TagBlockUtil.GetTagBlockForPoint contextPoint with
+            | None -> None
+            | Some tag ->
+                if target < tag.InnerSpan.Start then
+                    // End is exclusive but we want to go to '/' character of a </ClosingTag>
+                    Span(tag.InnerSpan.End + 1, 1) |> Some
+                else
+                    // Goes to first character of a tag, e.g. 'F' in <Foo>
+                    Span(tag.FullSpan.Start + 1, 1) |> Some
+
         let line, column = 
             let data = SnapshotColumn(point)
             let line = data.Line
@@ -976,8 +1038,10 @@ type MatchingTokenUtil() =
                 | MatchingTokenKind.Braces -> findMatchingTokenChar position BlockKind.CurlyBracket
                 | MatchingTokenKind.Brackets -> findMatchingTokenChar position BlockKind.Bracket
                 | MatchingTokenKind.Parens -> findMatchingTokenChar position BlockKind.Paren
+                | MatchingTokenKind.Chevrons -> findMatchingTokenChar position BlockKind.AngleBracket
                 | MatchingTokenKind.Directive -> findMatchingDirective position
                 | MatchingTokenKind.Comment -> findMatchingComment position
+                | MatchingTokenKind.Tag -> findMatchingTag position
 
         match found with
         | None -> None

--- a/Test/VimCoreTest/MatchingTokenUtilTest.cs
+++ b/Test/VimCoreTest/MatchingTokenUtilTest.cs
@@ -121,6 +121,13 @@ namespace Vim.UnitTest
                 Assert.Equal(matchLength, result.Value.Length);
             }
 
+            private void AssertNoMatch(int index)
+            {
+                var point = new SnapshotPoint(_textBuffer.CurrentSnapshot, index);
+                var result = _matchingTokenUtil.FindMatchingToken(point);
+                Assert.True(result.IsNone());
+            }
+
             [WpfFact]
             public void ParenSimple()
             {
@@ -229,6 +236,28 @@ namespace Vim.UnitTest
                 AssertMatch(0, line.IndexOf('>'), 1);
                 AssertMatch(line.IndexOf('>'), line.IndexOf('<'), 1);
                 AssertMatch(line.IndexOf('<'), line.IndexOf('>'), 1);
+            }
+
+            [WpfFact]
+            public void TagChevronsMultiline()
+            {
+                Create(
+                    "<tag",
+                    "attr=\"foo\">",
+                    "</tag>");
+                AssertMatch(_textBuffer.GetPointInLine(1, 0), _textBuffer.GetPointInLine(0, 0), 1);
+            }
+
+            [WpfFact]
+            public void TagChevronsRespectWhiteSpace()
+            {
+                Create(
+                    "if (",
+                    "  a < b && b > c",
+                    ")");
+                AssertNoMatch(_textBuffer.GetPointInLine(1, 0));
+                AssertNoMatch(_textBuffer.GetPointInLine(1, 4));
+                AssertNoMatch(_textBuffer.GetPointInLine(1, 13));
             }
 
             [WpfFact]

--- a/Test/VimCoreTest/MatchingTokenUtilTest.cs
+++ b/Test/VimCoreTest/MatchingTokenUtilTest.cs
@@ -210,6 +210,53 @@ namespace Vim.UnitTest
             }
 
             [WpfFact]
+            public void TagSimple()
+            {
+                var line = "<foo></foo>";
+                Create(line);
+                AssertMatch(line.IndexOf("foo"), line.IndexOf("/foo"), 1);
+                AssertMatch(line.IndexOf("/foo"), line.IndexOf("foo"), 1);
+
+                AssertMatch(line.IndexOf("foo") + 1, line.IndexOf("/foo"), 1);
+                AssertMatch(line.IndexOf("/foo") + 1, line.IndexOf("foo"), 1);
+            }
+
+            [WpfFact]
+            public void TagChevrons()
+            {
+                var line = " <foo>";
+                Create(line);
+                AssertMatch(0, line.IndexOf('>'), 1);
+                AssertMatch(line.IndexOf('>'), line.IndexOf('<'), 1);
+                AssertMatch(line.IndexOf('<'), line.IndexOf('>'), 1);
+            }
+
+            [WpfFact]
+            public void TagNested()
+            {
+                var line = "<foo><bar></bar></foo>";
+                Create(line);
+                AssertMatch(line.IndexOf("foo"), line.IndexOf("/foo"), 1);
+                AssertMatch(line.IndexOf("/foo"), line.IndexOf("foo"), 1);
+                AssertMatch(line.IndexOf("bar"), line.IndexOf("/bar"), 1);
+                AssertMatch(line.IndexOf("/bar"), line.IndexOf("bar"), 1);
+            }
+
+            [WpfFact]
+            public void TagMultiline()
+            {
+                Create(
+                    "<foo",
+                    "  attribute1=\"value\"",
+                    "  attribute2=\"value\">",
+                    "  content",
+                    "</foo>");
+
+                AssertMatch(_textBuffer.GetPointInLine(0, 1), _textBuffer.GetPointInLine(4, 1), 1);
+                AssertMatch(_textBuffer.GetPointInLine(4, 1), _textBuffer.GetPointInLine(0, 1), 1);
+            }
+
+            [WpfFact]
             public void Mixed()
             {
                 Create("{ { (( } /* a /*) b */ })");


### PR DESCRIPTION
this patch uses very rough heuristics relying on codestyle to achieve matching xml tags without messing up other file types. in the future this should be done based on current filetype (like matchit), but i am personally satisfied with this behavior for WPF/XAML workflows.
also, i am always returning span with length 1 in `findMatchingTag` because i did not see it used anywhere, but that might be an issue somewhere i am not aware of.