### PR TITLE
Add support for SSMS v21

### DIFF
--- a/Src/VsVim2022/source.extension.vsixmanifest
+++ b/Src/VsVim2022/source.extension.vsixmanifest
@@ -36,6 +36,9 @@
     <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
       <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Ssms" Version="[17.0,)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="VimCore" Path="|VimCore|" />


### PR DESCRIPTION
SSMS v21 has been rebuilt from the ground up based on Visual Studio Shell, therefore VsVim is now supported, however it won't install directly as it does not know anything about SSMS v21.

This update modifies the extension manifest to allow VsVim to natively be installed as an extension using the VSIX installer.

Screenshots below testing the installation and use in SSMS.

Installer.

<img width="878" height="660" alt="image" src="https://github.com/user-attachments/assets/8244d61d-44ed-4bab-9481-0b0b4d903a8e" />

Installation Complete.

<img width="878" height="660" alt="image" src="https://github.com/user-attachments/assets/0e073c93-3c8b-4d9a-b65c-8fa55d3a5105" />

Main SSMS v21 window showing first run.

<img width="3072" height="1824" alt="image" src="https://github.com/user-attachments/assets/9e56f0a3-371c-4402-b763-fae5a86ce068" />

Insert mode.

<img width="3072" height="1824" alt="image" src="https://github.com/user-attachments/assets/f9c7ad90-abdc-4ff4-9546-cd1b268caaf9" />

Visual Mode.

<img width="3072" height="1824" alt="image" src="https://github.com/user-attachments/assets/f87d7f62-0bbd-4226-98dd-2d2c5e53a4dc" />

Settings

<img width="1648" height="1386" alt="image" src="https://github.com/user-attachments/assets/38a8c44c-1458-47af-9674-94b08f798d79" />
 