### PR TITLE
Fix CI: Update from deprecated upload-artifact action & switch to macOS-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
 
   macos-build:
     name: MacOS Build and Publish
-    runs-on: macOS-11
+    runs-on: macOS-latest
 
     steps:
       # Must use fetch-depth 0 because the workflow requires that tags be present

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         run: Scripts\Build.ps1 -ci -config Debug -testExtra
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Logs
           path: Binaries\Logs
@@ -55,7 +55,7 @@ jobs:
         run: Scripts\Build.ps1 -ci -build -updateVsixVersion -config Release
 
       - name: Upload VSIX Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Vsix
           path: Binaries\Deploy
@@ -85,7 +85,7 @@ jobs:
         run: Scripts/build.sh
 
       - name: Publish mpack
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VSMacExtension
           path: 'Binaries/Debug/VimMac/net7.0/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'

--- a/VsVim.sln
+++ b/VsVim.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		License.txt = License.txt
+		.github\workflows\main.yml = .github\workflows\main.yml
 		README.ch.md = README.ch.md
 		README.md = README.md
 	EndProjectSection


### PR DESCRIPTION
The GitHub action runs were failing for two reasons:
- `actions/upload-artifact@v3` was deprecated. I upgraded to `v4`, there were no other changes needed for that migration
- `macOS-11` runners don't seem to be available anymore. I changed it to `macOS-latest`.