### PR TITLE
Overhaul build pipeline, introduce git-derived version numbering, and publish a private gallery directly from GH artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,101 +4,110 @@ name: VsVim CI
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main" ] # Branch builds with names starting with 'ma' will be published to this repo's releases feed
     tags:
       - '*'
-  pull_request:
-    branches: [ "master", "main", "dev/gha" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  windows-build:
-    name: Windows Build and Test
-    runs-on: windows-2022
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build
-        shell: powershell
-        run: Scripts\Build.ps1 -ci -config Debug -build 
-
-      - name: Test
-        shell: powershell
-        run: Scripts\Build.ps1 -ci -config Debug -test
-
-      - name: Test Extra
-        shell: powershell
-        run: Scripts\Build.ps1 -ci -config Debug -testExtra
-
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Logs
-          path: Binaries\Logs
-
-  # This job is meant for building a Release VSIX for consumption and 
-  # publishing it to two locations:
-  #   - An Azure DevOps artifact for easy download / use on PR or CI
-  #   - The Open VSIX gallery during CI
   windows-publish:
-    name: Publish VSIX
+    name: Build and publish
     runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+
+      - uses: dotnet/nbgv@master
+        id: nbgv
 
       - name: Build VSIX
         shell: powershell
-        run: Scripts\Build.ps1 -ci -build -updateVsixVersion -config Release
+        run: Scripts\Build.ps1 -ci -build -config Release
+
+      - name: Test
+        shell: powershell
+        run: Scripts\Build.ps1 -ci -config Release -test
+
+      - name: Test Extra
+        shell: powershell
+        run: Scripts\Build.ps1 -ci -config Release -testExtra
+
+      # The vsix is currently not listed on the Open VSIX Gallery: #3002
+      # - name: Publish VSIX to Open VSIX Gallery
+      #   shell: powershell
+      #   run: Scripts\Build.ps1 -ci -uploadVsix -config Release
+      #   if: ${{ success() && startsWith(github.ref, 'refs/tags') && contains(github.ref, 'gallery') }} # If a tag is pushed and its name contains 'gallery', publish it there
+
+      - name: Prepare VSIXes for artifact
+        shell: powershell
+        run: |
+          mkdir Binaries/ReleaseStaging
+          mv Binaries/Deploy/Release/2022/VsVim.vsix Binaries/ReleaseStaging/VsVim_${{ steps.nbgv.outputs.AssemblyFileVersion }}.vsix
+          mv Binaries/Deploy/Release/2019/VsVim.vsix Binaries/ReleaseStaging/VsVim2019_${{ steps.nbgv.outputs.AssemblyFileVersion }}.vsix
 
       - name: Upload VSIX Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Vsix
-          path: Binaries\Deploy
+          path: Binaries\ReleaseStaging
 
-      - name: Publish VSIX to Open VSIX Gallery
+      - id: tag_name
+        name: Compose tag name
         shell: powershell
-        run: Scripts\Build.ps1 -ci -uploadVsix -config Release
-        if: ${{ success() && github.ref == 'refs/heads/master' }}
+        if: ${{ success() && startswith(github.ref, 'refs/heads/ma') }}
+        run: |
+          $commitDate = "${{ steps.nbgv.outputs.GitCommitDate }}"
+          $commitDate = [DateTime]::parse($commitDate)
+          $commitDate = $commitDate.ToString("yyyyMMdd")
+          $simpleVersion = "${{ steps.nbgv.outputs.SimpleVersion }}"
+          $tag = "ci-$commitDate-$simpleVersion-vsix"
+          echo "Tag: $tag"
+          echo "tag=$tag`n" >> $env:GITHUB_OUTPUT
+      - name: Create CI release tag
+        if: ${{ success() && startswith(github.ref, 'refs/heads/ma') }}
+        run: |
+          echo "creating tag: ${{ steps.tag_name.outputs.tag }}"
+          git tag ${{ steps.tag_name.outputs.tag }}
+          git push origin ${{ steps.tag_name.outputs.tag }}
 
-  macos-build:
-    name: MacOS Build and Publish
-    runs-on: macOS-latest
+      - name: Build VSIX feed
+        shell: powershell
+        if: ${{ success() && startswith(github.ref, 'refs/heads/ma') }}
+        run: |
+          $zipName = "PrivateGalleryCreator.zip"
+          Invoke-WebRequest -Uri https://github.com/madskristensen/PrivateGalleryCreator/releases/download/1.0.64/PrivateGalleryCreator.zip -OutFile $zipName
+          $zipHash = (Get-FileHash $zipName).Hash
+          $expectedZipHash = "B410F7C9B93D319F5B7791687DEDA08378955AE45B7B5BD7EFC65D937FC160CA"
+          if ($zipHash -ne $expectedZipHash) {
+            Write-Error "$zipName integrity check failed; expected $expectedZipHash, got $zipHash"
+            exit 1
+          }
+ 
+          Expand-Archive PrivateGalleryCreator.zip -DestinationPath .
+          $tool = Resolve-Path ./PrivateGalleryCreator.exe
+          pushd Binaries/ReleaseStaging
+          $tag = "${{ steps.tag_name.outputs.tag }}"
+          $ghRepo = "${{ github.repository }}"
+          & $tool --input=$(pwd) --source="https://github.com/$ghRepo/releases/download/$tag/" -t
+          cat feed.xml
 
-    steps:
-      # Must use fetch-depth 0 because the workflow requires that tags be present
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set VERSION_TAG
-        run: echo "VERSION_TAG=`git describe --tags`" >> $GITHUB_ENV
-
-      - name: Set EXTENSION_VERSION
-        run: echo "EXTENSION_VERSION=`grep Version Src/VimMac/Properties/AddinInfo.cs | cut -d '\"' -f2`" >> $GITHUB_ENV
-
-      - name: Build
-        run: Scripts/build.sh
-
-      - name: Publish mpack
-        uses: actions/upload-artifact@v4
-        with:
-          name: VSMacExtension
-          path: 'Binaries/Debug/VimMac/net7.0/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'
-
-      - name: Create VS Mac extension release
+      - name: Create VS extension release
         uses: softprops/action-gh-release@v1
-        id: vsmac_release
+        if: ${{ success() && startswith(github.ref, 'refs/heads/ma') }}
+        id: vsix_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         with:
-          tag_name: ${{ env.VERSION_TAG }}
-          name: 'Visual Studio for Mac ${{ env.VERSION_TAG }}'
+          name: 'VSVim ${{ steps.nbgv.outputs.AssemblyInformationalVersion }}'
+          tag_name: '${{ steps.tag_name.outputs.tag }}'
           draft: false
           generate_release_notes: true
-          files: 'Binaries/Debug/VimMac/net7.0/Vim.Mac.VsVim_${{ env.EXTENSION_VERSION }}.mpack'
-        if: ${{ success() && startsWith(github.ref, 'refs/tags') && contains(github.ref, 'vsm') }}
+          fail_on_unmatched_files: true
+          files: |
+            Binaries/ReleaseStaging/VsVim_${{ steps.nbgv.outputs.AssemblyFileVersion }}.vsix
+            Binaries/ReleaseStaging/VsVim2019_${{ steps.nbgv.outputs.AssemblyFileVersion }}.vsix
+            Binaries/ReleaseStaging/feed.xml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,52 @@
+name: VsVim PR
+
+on:
+  pull_request:
+    branches: [ "master", "main", "dev/gha" ]
+
+jobs:
+  windows-build:
+    name: Debug build
+    runs-on: windows-2022
+    outputs:
+      tag_name: ${{ steps.tag_name.outputs.tag }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+
+      - uses: dotnet/nbgv@master
+        id: nbgv
+
+      - name: Build
+        shell: powershell
+        run: Scripts\Build.ps1 -ci -config Debug -build 
+
+      - name: Test
+        shell: powershell
+        run: Scripts\Build.ps1 -ci -config Debug -test
+
+      - name: Test Extra
+        shell: powershell
+        run: Scripts\Build.ps1 -ci -config Debug -testExtra
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: Logs
+          path: Binaries\Logs
+
+      - name: Prepare VSIXes for artifact
+        shell: powershell
+        run: |
+          mkdir Binaries/ReleaseStaging
+          mv Binaries/Deploy/Release/2022/VsVim.vsix Binaries/ReleaseStaging/VsVim_${{ steps.nbgv.outputs.AssemblyFileVersion }}.vsix
+          mv Binaries/Deploy/Release/2019/VsVim.vsix Binaries/ReleaseStaging/VsVim2019_${{ steps.nbgv.outputs.AssemblyFileVersion }}.vsix
+
+      - name: Upload VSIX Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Vsix
+          path: Binaries\ReleaseStaging

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,5 @@
 <Project>
-
   <Import Project="$(MSBuildThisFileDirectory)\Binaries\User.props" Condition="Exists('$(MSBuildThisFileDirectory)\Binaries\User.props')" />
-
   <PropertyGroup>
     <RepoPath>$(MSBuildThisFileDirectory)</RepoPath>
     <DebugType>full</DebugType>
@@ -10,18 +8,16 @@
     <OutputPath>$(BinariesPath)$(Configuration)\$(MSBuildProjectName)</OutputPath>
     <BaseIntermediateOutputPath>$(BinariesPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <MicrosoftVsSdkBuildToolsVersion>17.0.5232</MicrosoftVsSdkBuildToolsVersion>
-
     <!-- Standard Calculation of NuGet package location -->
-    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot> <!-- Respect environment variable if set -->
+    <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot>
+    <!-- Respect environment variable if set -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' == 'Windows_NT'">$(UserProfile)/.nuget/packages/</NuGetPackageRoot>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' AND '$(OS)' != 'Windows_NT'">$(HOME)/.nuget/packages/</NuGetPackageRoot>
-
     <!-- 
       VSTHRD010: this warning is extremely noisy and in practice has not found any issues
     -->
     <NoWarn>$(NoWarn);VSTHRD010</NoWarn>
   </PropertyGroup>
-
   <!--
       When building WPF projects MSBuild will create a temporary project with an extension of
       tmp_proj.  In that case the SDK is unable to determine the target language and cannot pick
@@ -32,13 +28,11 @@
     <Language>C#</Language>
     <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
   </PropertyGroup>
-
-  <PropertyGroup> 
+  <PropertyGroup>
     <ReferencePath>$(ReferencePath);$(MSBuildThisFileDirectory)References\Common</ReferencePath>
     <ReferencePath>$(ReferencePath);$(MSBuildThisFileDirectory)References\Vs2019</ReferencePath>
     <ReferencePath>$(ReferencePath);$(MSBuildThisFileDirectory)References\Vs2022</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildThisFileDirectory)</SolutionDir>
-
     <!-- This controls the places MSBuild will consult to resolve assembly references.  This is 
          kept as minimal as possible to make our build reliable from machine to machine.  Global
          locations such as GAC, AssemblyFoldersEx, etc ... are deliberately removed from this 
@@ -49,5 +43,13 @@
       $(ReferencePath);  
     </AssemblySearchPaths>
   </PropertyGroup>
-
+  <PropertyGroup>
+    <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.7.115</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ is available in the same directory under the name License.txt.
 
 ## Latest Builds
 
+Build of the latest source code can be downloaded from https://github.com/vsvim/VsVim/releases.
+
+If you would like to get the latest updates automatically, you can add the following feed url to Visual Studio as an Additional Extension Gallery:
+```
+https://github.com/vsvim/VsVim/releases/latest/download/feed.xml
+```
+
 The build representing the latest source code can be downloaded from the
 [Open Vsix Gallery](http://vsixgallery.com/extension/VsVim.Microsoft.e214908b-0458-4ae2-a583-4310f29687c3/).  
 

--- a/Src/VimCore/Constants.fs
+++ b/Src/VimCore/Constants.fs
@@ -37,11 +37,9 @@ module VimConstants =
     let MainKeyProcessorName = "VsVim";
 
 #if DEBUG
-    [<Literal>]
-    let VersionNumber = "2.10.99.99 Debug"
+    let VersionNumber = $"{ThisAssembly.AssemblyInformationalVersion} Debug";
 #else
-    [<Literal>]
-    let VersionNumber = "2.10.0.5"
+    let VersionNumber = ThisAssembly.AssemblyInformationalVersion;
 #endif
 
 

--- a/Src/VimCore/VimCore.fsproj
+++ b/Src/VimCore/VimCore.fsproj
@@ -3,6 +3,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.Core</RootNamespace>
     <AssemblyName>Vim.Core</AssemblyName>
+    <NBGV_ThisAssemblyNamespace>Vim</NBGV_ThisAssemblyNamespace>
     <TargetFrameworks>net472;net7.0</TargetFrameworks>
     <OtherFlags>--standalone</OtherFlags>
     <LangVersion>8</LangVersion>

--- a/Src/VsVim2019/VsVim2019.csproj
+++ b/Src/VsVim2019/VsVim2019.csproj
@@ -5,6 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.VisualStudio</RootNamespace>
+    <NBGV_ThisAssemblyNamespace>$(RootNamespace)</NBGV_ThisAssemblyNamespace>
     <AssemblyName>VsVim</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <StartAction>Program</StartAction>
@@ -14,6 +15,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <VsVimProjectType>Vsix</VsVimProjectType>
     <VsVimVisualStudioTargetVersion>16.0</VsVimVisualStudioTargetVersion>
+    <UseWPF>true</UseWPF>
 
     <DeployExtension Condition="'$(VisualStudioVersion)' != '16.0' OR '$(BuildingInsideVisualStudio)' != 'true'">False</DeployExtension>
 

--- a/Src/VsVim2019/source.extension.vsixmanifest
+++ b/Src/VsVim2019/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Publisher="Jared Parsons" Version="2.10.0.5" Id="VsVim.Microsoft.e214908b-0458-4ae2-a583-4310f29687c3" Language="en-US" />
+    <Identity Publisher="Jared Parsons" Version="|%CurrentProject%;GetBuildVersion|" Id="VsVim.Microsoft.e214908b-0458-4ae2-a583-4310f29687c3" Language="en-US" />
     <DisplayName>VsVim</DisplayName>
     <Description>VIM emulation layer for Visual Studio</Description>
     <MoreInfo>https://github.com/VsVim/VsVim</MoreInfo>

--- a/Src/VsVim2022/VsVim2022.csproj
+++ b/Src/VsVim2022/VsVim2022.csproj
@@ -4,6 +4,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Vim.VisualStudio</RootNamespace>
+    <NBGV_ThisAssemblyNamespace>$(RootNamespace)</NBGV_ThisAssemblyNamespace>
     <AssemblyName>VsVim</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <StartAction>Program</StartAction>
@@ -13,6 +14,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <VsVimProjectType>Vsix</VsVimProjectType>
     <VsVimVisualStudioTargetVersion>17.0</VsVimVisualStudioTargetVersion>
+    <UseWPF>true</UseWPF>
 
     <DeployExtension Condition="'$(VisualStudioVersion)' != '17.0' OR '$(BuildingInsideVisualStudio)' != 'true'">False</DeployExtension>
 

--- a/Src/VsVim2022/source.extension.vsixmanifest
+++ b/Src/VsVim2022/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <!-- DEV17_TODO -->
-    <Identity Publisher="Jared Parsons" Version="2.10.0.5" Id="VsVim.Microsoft.e97cd707-324b-4e35-a669-eef8dae4b8cf" Language="en-US" />
+    <Identity Publisher="Jared Parsons" Version="|%CurrentProject%;GetBuildVersion|" Id="VsVim.Microsoft.e97cd707-324b-4e35-a669-eef8dae4b8cf" Language="en-US" />
     <DisplayName>VsVim 2022</DisplayName>
     <Description>VIM emulation layer for Visual Studio</Description>
     <MoreInfo>https://github.com/VsVim/VsVim</MoreInfo>

--- a/Src/VsVimShared/VsVimPackage.cs
+++ b/Src/VsVimShared/VsVimPackage.cs
@@ -25,7 +25,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Vim.VisualStudio
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", productId: VimConstants.VersionNumber, IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", productId: ThisAssembly.AssemblyInformationalVersion, IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideOptionPage(typeof(Vim.VisualStudio.Implementation.OptionPages.DefaultOptionPage), categoryName: "VsVim", pageName: "Defaults", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
     [ProvideOptionPage(typeof(Vim.VisualStudio.Implementation.OptionPages.KeyboardOptionPage), categoryName: "VsVim", pageName: "Keyboard", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]

--- a/version.json
+++ b/version.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "2.11-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true,
+      "setVersionVariables": true
+    }
+  }
+}


### PR DESCRIPTION
This PR:

- Publishes CI builds as artifacts without wrapping them in a zip ([example from my fork](https://github.com/vivlim/VsVim/releases/tag/ci-20251017-2.11.3-vsix))
- Adds Nerdbank.GitVersioning and uses it to derive version numbers from git history, resulting in each commit's build having a different version number - no more having to manually bump version numbers
- Removes the Mac build from the pipeline to reduce complexity and maintenance overhead, since VS for Mac is EOL.
- Generates and publishes a feed.xml file that can be [used in VS as a private gallery to subscribe to CI builds](https://learn.microsoft.com/en-us/visualstudio/extensibility/private-galleries?view=visualstudio).
  - If you would like to try this and install builds from my fork, you can try adding this feed url:
```
https://github.com/vivlim/VsVim/releases/latest/download/feed.xml
```

Regarding #3162, having this private gallery is a significant usability improvement for installing builds directly from the master branch, but it doesn't replace the need to publish to the marketplace. I see it as a complementary addition (... and also, I wanted to see if it would work)

I've worked on this PR intermittently over a few months so I'll also need to review it myself to make sure I didn't leave anything half-baked, but I think it's in a reviewable state.