### PR TITLE
Guard async tagger against invalid line ranges

### DIFF
--- a/Src/VimCore/EditorUtil.fs
+++ b/Src/VimCore/EditorUtil.fs
@@ -181,7 +181,7 @@ type LineRange
 
     static member CreateFromBounds (startLineNumber: int) (lastLineNumber: int) = 
         if (lastLineNumber < startLineNumber) then
-            raise (new ArgumentOutOfRangeException("lastLineNumber", "Must be greater than startLineNmuber"))
+            raise (new ArgumentOutOfRangeException("lastLineNumber", "Must be greater than startLineNumber"))
 
         let count = (lastLineNumber - startLineNumber) + 1;
         new LineRange(startLineNumber, count)

--- a/Src/VimCore/TaggerUtil.fs
+++ b/Src/VimCore/TaggerUtil.fs
@@ -409,67 +409,79 @@ type internal CompleteReason =
 type internal NormalizedLineRangeCollection() = 
 
     let _list = List<LineRange>()
+    let isValid (lineRange: LineRange) =
+        lineRange.Count > 0 && lineRange.LastLineNumber >= lineRange.StartLineNumber
 
     member x.OverarchingLineRange =
-        match _list.Count with
-        | 0 -> None
-        | 1 -> _list.[0] |> Some
-        | _ -> 
-            let startLine = _list.[0].StartLineNumber
-            let lastLine = _list.[_list.Count - 1].LastLineNumber
+        let mutable startLine = Int32.MaxValue
+        let mutable lastLine = Int32.MinValue
+        let mutable index = 0
+        while index < _list.Count do
+            let lineRange = _list.[index]
+            if isValid lineRange then
+                startLine <- min startLine lineRange.StartLineNumber
+                lastLine <- max lastLine lineRange.LastLineNumber
+            index <- index + 1
+        if startLine <= lastLine then
             LineRange.CreateFromBounds startLine lastLine |> Some
+        else
+            None
     member x.Count = _list.Count    
     member x.Item
         with get(index) = _list.[index]
        
     member x.Add (lineRange: LineRange) = 
-        match x.FindInsertionPoint lineRange.StartLineNumber with
-        | None ->
-            // Just insert at the end and let the collapse code do the work in this case 
-            _list.Add(lineRange)
-            x.CollapseIntersecting (_list.Count - 1)
-        | Some index ->
-            // Quick optimization check to avoid copying the contents of the List
-            // structure down on insert
-            let item = _list.[index]
-            if item.StartLineNumber = lineRange.StartLineNumber || lineRange.ContainsLineNumber(item.StartLineNumber) then
-                _list.[index] <- LineRange.CreateOverarching item lineRange
-            else
-                _list.Insert(index, lineRange)
-            x.CollapseIntersecting(index);
-       
+        if isValid lineRange then
+            match x.FindInsertionPoint lineRange.StartLineNumber with
+            | None ->
+                // Just insert at the end and let the collapse code do the work in this case 
+                _list.Add(lineRange)
+                x.CollapseIntersecting (_list.Count - 1)
+            | Some index ->
+                // Quick optimization check to avoid copying the contents of the List
+                // structure down on insert
+                let item = _list.[index]
+                if item.StartLineNumber = lineRange.StartLineNumber || lineRange.ContainsLineNumber(item.StartLineNumber) then
+                    _list.[index] <- LineRange.CreateOverarching item lineRange
+                else
+                    _list.Insert(index, lineRange)
+                x.CollapseIntersecting(index);
+        
     member x.Clear () = _list.Clear()
 
-    member x.Contains lineRange = _list |> Seq.exists (fun x -> x.Contains lineRange)
+    member x.Contains lineRange = isValid lineRange && (_list |> Seq.exists (fun x -> x.Contains lineRange))
 
     member x.Copy () = NormalizedLineRangeCollection.Create _list
 
     /// Get the unvisited lines in the specified range
     member x.GetUnvisited lineRange = 
-        let mutable value = Some lineRange
-        let mutable index = 0
-        while index < _list.Count do
-            let current = _list.[index]
-            if current.Intersects lineRange then
+        if not (isValid lineRange) then
+            None
+        else
+            let mutable value = Some lineRange
+            let mutable index = 0
+            while index < _list.Count do
+                let current = _list.[index]
+                if current.Intersects lineRange then
 
-                if current.Contains(lineRange) then
-                    // Already have a LineRange which completely contains the provided 
-                    // value.  No unvisited values
-                    value <- None
-                    index <- _list.Count
-                elif current.StartLineNumber <= lineRange.StartLineNumber then
-                    // The found range starts before and intersects.  The unvisited section 
-                    // is the range below
-                    value <- LineRange.CreateFromBounds (current.LastLineNumber + 1) (lineRange.LastLineNumber) |> Some
-                    index <- _list.Count
-                elif current.StartLineNumber > lineRange.StartLineNumber then
-                    // The found range starts below and intersects.  The unvisited section 
-                    // is the line range above
-                    value <- LineRange.CreateFromBounds lineRange.StartLineNumber (current.StartLineNumber - 1) |> Some
-                    index <- _list.Count
-            else
-                index <- index + 1
-        value
+                    if current.Contains(lineRange) then
+                        // Already have a LineRange which completely contains the provided 
+                        // value.  No unvisited values
+                        value <- None
+                        index <- _list.Count
+                    elif current.StartLineNumber <= lineRange.StartLineNumber then
+                        // The found range starts before and intersects.  The unvisited section 
+                        // is the range below
+                        value <- LineRange.CreateFromBounds (current.LastLineNumber + 1) (lineRange.LastLineNumber) |> Some
+                        index <- _list.Count
+                    elif current.StartLineNumber > lineRange.StartLineNumber then
+                        // The found range starts below and intersects.  The unvisited section 
+                        // is the line range above
+                        value <- LineRange.CreateFromBounds lineRange.StartLineNumber (current.StartLineNumber - 1) |> Some
+                        index <- _list.Count
+                else
+                    index <- index + 1
+            value
 
     /// This is the helper method for Add which will now collapse elements that intersect.   We only have
     /// to look at the item before the insert and all items after and not the entire collection.

--- a/Test/VimCoreTest/AsyncTaggerTest.cs
+++ b/Test/VimCoreTest/AsyncTaggerTest.cs
@@ -400,6 +400,29 @@ namespace Vim.UnitTest
                 Assert.Equal(_textBuffer.GetSpan(0, 1), tags[0].Span);
             }
 
+            [WpfFact]
+            public void InvalidRangeInCacheDoesNotThrow()
+            {
+                Create("cat", "dog", "bear");
+                var span = _textBuffer.GetSpan(1, 2);
+                _asyncTaggerSource.SetBackgroundTags(span);
+
+                var visitedCollection = new NormalizedLineRangeCollection
+                {
+                    new LineRange(10, -20),
+                };
+                var backgroundData = new BackgroundCacheData<TextMarkerTag>(
+                    _textBuffer.CurrentSnapshot,
+                    visitedCollection,
+                    CreateTagSpans(span));
+                _asyncTagger.TagCacheData = new TagCache<TextMarkerTag>(FSharpOption.Create(backgroundData), null);
+
+                var tags = GetTagsFull(_textBuffer.GetExtent(), out bool wasAsync);
+                Assert.Single(tags);
+                Assert.Equal(span, tags[0].Span);
+                Assert.True(wasAsync);
+            }
+
             /// <summary>
             /// When there are no prompt sources available for tags we should schedule this
             /// for the background thread

--- a/Test/VimCoreTest/NormalizedLineRangeCollectionTest.cs
+++ b/Test/VimCoreTest/NormalizedLineRangeCollectionTest.cs
@@ -197,5 +197,13 @@ namespace Vim.UnitTest
             col.Clear();
             Assert.Equal(0, col.Count);
         }
+
+        [Fact]
+        public void InvalidRangeIgnored()
+        {
+            var col = Create(LineRange.CreateFromBounds(5, 5), new LineRange(10, -20));
+            Assert.Equal(1, col.Count);
+            Assert.Equal(LineRange.CreateFromBounds(5, 5), col.OverarchingLineRange.Value);
+        }
     }
 }


### PR DESCRIPTION
I got a gold bar reporting an ArgumentOutOfRangeException. The log shows 41 error entries:
```
2026/04/10 14:25:28.817–14:25:32.224  Error  Editor or Editor Extension
 System.ArgumentOutOfRangeException: Must be greater than startLineNmuber
 Parameter name: lastLineNumber
    at Vim.LineRange.CreateFromBounds(Int32 startLineNumber, Int32 lastLineNumber)
    at Vim.NormalizedLineRangeCollection.get_OverarchingLineRange()
    at Vim.BackgroundCacheData`1.get_Span()
    at Vim.BackgroundCacheData`1.GetTagCacheState(SnapshotSpan span)
    at Vim.AsyncTagger`2.GetTagsFromBackgroundDataCache(SnapshotSpan span)
    at Vim.AsyncTagger`2.GetTagsForSpan(SnapshotSpan span)
    at Vim.AsyncTagger`2.GetTags(NormalizedSnapshotSpanCollection col)
    at Microsoft.VisualStudio.Text.Utilities.GuardedOperations.CallExtensionPoint...
    ...
    at Microsoft.VisualStudio.Text.Editor.Implementation.WpfTextViewHost.OnMouseWheel
```    

Copilot summary of what likely happened:

 1. Async tagging was running while the view was changing. The stack shows Vim.AsyncTagger, BackgroundCacheData, and then OnMouseWheel, so this was happening during scroll/layout updates.
 2. VsVim keeps a cached NormalizedLineRangeCollection of “visited” lines for tagging.
 3. One bad internal LineRange slipped into that collection during snapshot/layout churn.
 4. OverarchingLineRange then assumed the collection was valid and called CreateFromBounds(start, last), which threw when last < start.

Even if an editor/layout race contributes the triggering state, VsVim should not throw from its tagger pipeline when presented with an invalid internal range.