### PR TITLE
Changing clipboard implementation to prevent freeze when attempting to yank

### DIFF
--- a/Src/VimWpf/Implementation/Misc/ClipboardDevice.cs
+++ b/Src/VimWpf/Implementation/Misc/ClipboardDevice.cs
@@ -1,73 +1,171 @@
-﻿using System;
+using System;
 using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
 using System.Threading;
-using System.Windows;
 
 namespace Vim.UI.Wpf.Implementation.Misc
 {
     [Export(typeof(IClipboardDevice))]
     internal sealed class ClipboardDevice : IClipboardDevice
     {
-        private readonly IProtectedOperations _protectedOperations;
+        private static class NativeMethods
+        {
+            public const uint CF_UNICODETEXT = 13;
+            public const uint GMEM_MOVEABLE = 0x0002;
+
+            [DllImport("user32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool CloseClipboard();
+
+            [DllImport("user32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool EmptyClipboard();
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern IntPtr GetClipboardData(uint uFormat);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern IntPtr GlobalAlloc(uint uFlags, UIntPtr dwBytes);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern IntPtr GlobalLock(IntPtr hMem);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool GlobalUnlock(IntPtr hMem);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern IntPtr GlobalFree(IntPtr hMem);
+        }
 
         private bool _reportErrors;
 
         [ImportingConstructor]
         internal ClipboardDevice(IProtectedOperations protectedOperations)
         {
-            _protectedOperations = protectedOperations;
             _reportErrors = false;
         }
 
-        private string GetText()
+        /// <summary>
+        /// Read clipboard text via Win32 directly, retrying on contention.
+        /// Runs on a background thread so Thread.Sleep doesn't block the UI.
+        /// </summary>
+        private static string GetText()
         {
-            string text = null;
-            void action()
-            {
-                text = Clipboard.GetText();
-            }
-
-            if (!TryAccessClipboard(action))
-            {
-                text = string.Empty;
-            }
-
-            return text;
-        }
-
-        private void SetText(string text)
-        {
-            void action()
-            {
-                Clipboard.SetText(text);
-            }
-
-            TryAccessClipboard(action);
+            string result = string.Empty;
+            var thread = new Thread(() => { result = Win32GetText(); });
+            thread.IsBackground = true;
+            thread.Start();
+            thread.Join();
+            return result;
         }
 
         /// <summary>
-        /// The clipboard is a shared resource across all applications.  It can only be used 
-        /// by one application at a time and has no mechanism for synchronizing access.  
-        ///
-        /// Use of the clipboard should be short lived though so most applications guard 
-        /// against races by simply retrying the access a number of times.  This is how 
-        /// WinForms handles the race.  WPF does not do this hence we have to implement it 
-        /// manually here. 
+        /// Write clipboard text via Win32 directly, fire-and-forget on a background
+        /// thread. Skips Flush() entirely — no second OpenClipboard, no UI freeze.
+        /// VsVim's internal register is the authoritative store; the system clipboard
+        /// update doesn't need to complete synchronously.
         /// </summary>
-        private bool TryAccessClipboard(Action action)
+        private static void SetText(string text)
         {
-            try
+            var thread = new Thread(() => Win32SetText(text));
+            thread.IsBackground = true;
+            thread.Start();
+        }
+
+        private static string Win32GetText()
+        {
+            const int maxRetries = 5;
+            for (int i = 0; i < maxRetries; i++)
             {
-                action();
-                return true;
-            }
-            catch (Exception ex)
-            {
-                if (_reportErrors)
+                if (NativeMethods.OpenClipboard(IntPtr.Zero))
                 {
-                    _protectedOperations.Report(ex);
+                    try
+                    {
+                        IntPtr hData = NativeMethods.GetClipboardData(NativeMethods.CF_UNICODETEXT);
+                        if (hData == IntPtr.Zero)
+                            return string.Empty;
+
+                        IntPtr pData = NativeMethods.GlobalLock(hData);
+                        if (pData == IntPtr.Zero)
+                            return string.Empty;
+
+                        try
+                        {
+                            return Marshal.PtrToStringUni(pData) ?? string.Empty;
+                        }
+                        finally
+                        {
+                            NativeMethods.GlobalUnlock(hData);
+                        }
+                    }
+                    finally
+                    {
+                        NativeMethods.CloseClipboard();
+                    }
                 }
-                return false;
+
+                if (i < maxRetries - 1)
+                    Thread.Sleep(10);
+            }
+
+            return string.Empty;
+        }
+
+        private static void Win32SetText(string text)
+        {
+            const int maxRetries = 5;
+            for (int i = 0; i < maxRetries; i++)
+            {
+                if (NativeMethods.OpenClipboard(IntPtr.Zero))
+                {
+                    try
+                    {
+                        NativeMethods.EmptyClipboard();
+
+                        int charCount = text.Length + 1;
+                        IntPtr hMem = NativeMethods.GlobalAlloc(NativeMethods.GMEM_MOVEABLE, (UIntPtr)(charCount * 2));
+                        if (hMem == IntPtr.Zero)
+                            return;
+
+                        IntPtr pMem = NativeMethods.GlobalLock(hMem);
+                        if (pMem == IntPtr.Zero)
+                        {
+                            NativeMethods.GlobalFree(hMem);
+                            return;
+                        }
+
+                        try
+                        {
+                            Marshal.Copy(text.ToCharArray(), 0, pMem, text.Length);
+                            Marshal.WriteInt16(pMem, text.Length * 2, 0);
+                        }
+                        finally
+                        {
+                            NativeMethods.GlobalUnlock(hMem);
+                        }
+
+                        if (NativeMethods.SetClipboardData(NativeMethods.CF_UNICODETEXT, hMem) != IntPtr.Zero)
+                            return; // success; SetClipboardData owns hMem now
+
+                        // SetClipboardData failed; we still own hMem
+                        NativeMethods.GlobalFree(hMem);
+                    }
+                    finally
+                    {
+                        NativeMethods.CloseClipboard();
+                    }
+                }
+
+                if (i < maxRetries - 1)
+                    Thread.Sleep(10);
             }
         }
 


### PR DESCRIPTION
I'm a game dev who works primarily in C++. C# isn't my forte, I haven't touched it since college (about 2 decades ago), and I've never made an extension for VS before. But I've been using VsVim for years, and I've tried all kinds of workarounds for yank either freezing, failing, or not using the unnamed clipboard, and it's been the bane of my existence forever.

So I forked the project, and spent some time with Claude working through it, and have what appears to be a solution. I managed to run the extension in a VS 2022 build (17.14.30), and the yank worked as expected, with no delay/freezing, and I was able to paste the text across different apps. Feel free to tear apart the PR, but please take a look, test it out in your own environment, and see if it can help, because I've now got a release vsix running on my local install, and I feel so much better about life now.

Related tickets:
[Visual Studio lags for ~4 seconds when yanking or deleting to clipboard (set clipboard = unnamed)](https://github.com/VsVim/VsVim/issues/2948)
["Yank" hangs Visual Studio for 3 seconds before continuing with clipboard=unnamed](https://github.com/VsVim/VsVim/issues/3116)
[System clipboard operations unusable slow after update to VS2022 17.5](https://github.com/VsVim/VsVim/issues/3040)
[System clipboard copy operation causes lag on a KVM guest.](https://github.com/VsVim/VsVim/issues/3038)